### PR TITLE
Restart API when changing checks

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -69,4 +69,6 @@
     when: sensu_master
     with_lines:
       - ls {{ static_data_store }}/sensu/definitions | sed 's/\.j2//'
-    notify: restart sensu-server service
+    notify: 
+      - restart sensu-server service
+      - restart sensu-api service


### PR DESCRIPTION
We need to restart the API when changing checks. If we don't do this the /checks endpoint will not be updated. 
