### PR TITLE
Improve Vagrant setup

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+# Ignore provisioning artifacts
+data/
+*.retry

--- a/tests/vms/Vagrantfile.centos7
+++ b/tests/vms/Vagrantfile.centos7
@@ -8,39 +8,39 @@ Vagrant.configure(2) do | config |
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
-   config.vm.define "centos7" do |centos7|
+  config.vm.define "centos7" do |centos7|
     centos7.vm.hostname = "centos7.dev"
     centos7.vm.box = "geerlingguy/centos7"
     centos7.vm.network :private_network, ip: "192.168.40.4"
     centos7.vm.network "forwarded_port", guest: 3000, host: 3001
-  end
 
-  # Ansible
-  config.vm.provision "ansible" do |ansible|
-    ansible.groups = {
-      "sensu_masters" => ["centos7"],
-      "rabbitmq_servers" => ["centos7"],
-      "redis_servers" => ["centos7"],
-    }
+    # Ansible
+    config.vm.provision "ansible" do |ansible|
+      ansible.groups = {
+        "sensu_masters" => ["centos7"],
+        "rabbitmq_servers" => ["centos7"],
+        "redis_servers" => ["centos7"],
+      }
 
-    ansible.extra_vars = {
-      dynamic_data_store: "data/dynamic",
-      rabbitmq_host: "192.168.40.4",
-      rabbitmq_server: true,
-      redis_host: "192.168.40.4",
-      redis_server: true,
-      sensu_api_host: "192.168.40.4",
-      sensu_api_user_name: "admin",
-      sensu_api_password: "admin",
-      sensu_include_plugins: false,
-      sensu_include_dashboard: true,
-      sensu_master: true,
-      uchiwa_dc_name: "vagrant",
-      uchiwa_user_name: "admin",
-      uchiwa_password: "admin",
-    }
+      ansible.extra_vars = {
+        dynamic_data_store: "data/dynamic",
+        rabbitmq_host: "192.168.40.4",
+        rabbitmq_server: true,
+        redis_host: "192.168.40.4",
+        redis_server: true,
+        sensu_api_host: "192.168.40.4",
+        sensu_api_user_name: "admin",
+        sensu_api_password: "admin",
+        sensu_include_plugins: false,
+        sensu_include_dashboard: true,
+        sensu_master: true,
+        uchiwa_dc_name: "vagrant",
+        uchiwa_user_name: "admin",
+        uchiwa_password: "admin",
+      }
 
-    ansible.sudo = true
-    ansible.playbook = "provision.yml"
+      ansible.sudo = true
+      ansible.playbook = "provision.yml"
+    end
   end
 end

--- a/tests/vms/Vagrantfile.debian8
+++ b/tests/vms/Vagrantfile.debian8
@@ -8,39 +8,39 @@ Vagrant.configure(2) do | config |
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
-   config.vm.define "debian8" do |debian8|
+  config.vm.define "debian8" do |debian8|
     debian8.vm.hostname = "debian8.dev"
     debian8.vm.box = "debian/jessie64"
     debian8.vm.network :private_network, ip: "192.168.40.5"
     debian8.vm.network "forwarded_port", guest: 3000, host: 3002
-  end
 
-  # Ansible
-  config.vm.provision "ansible" do |ansible|
-    ansible.groups = {
-      "sensu_masters" => ["debian8"],
-      "rabbitmq_servers" => ["debian8"],
-      "redis_servers" => ["debian8"],
-    }
+    # Ansible
+    config.vm.provision "ansible" do |ansible|
+      ansible.groups = {
+        "sensu_masters" => ["debian8"],
+        "rabbitmq_servers" => ["debian8"],
+        "redis_servers" => ["debian8"],
+      }
 
-    ansible.extra_vars = {
-      dynamic_data_store: "data/dynamic",
-      rabbitmq_host: "192.168.40.5",
-      rabbitmq_server: true,
-      redis_host: "192.168.40.5",
-      redis_server: true,
-      sensu_api_host: "192.168.40.5",
-      sensu_api_user_name: "admin",
-      sensu_api_password: "admin",
-      sensu_include_plugins: false,
-      sensu_include_dashboard: true,
-      sensu_master: true,
-      uchiwa_dc_name: "vagrant",
-      uchiwa_user_name: "admin",
-      uchiwa_password: "admin",
-    }
+      ansible.extra_vars = {
+        dynamic_data_store: "data/dynamic",
+        rabbitmq_host: "192.168.40.5",
+        rabbitmq_server: true,
+        redis_host: "192.168.40.5",
+        redis_server: true,
+        sensu_api_host: "192.168.40.5",
+        sensu_api_user_name: "admin",
+        sensu_api_password: "admin",
+        sensu_include_plugins: false,
+        sensu_include_dashboard: true,
+        sensu_master: true,
+        uchiwa_dc_name: "vagrant",
+        uchiwa_user_name: "admin",
+        uchiwa_password: "admin",
+      }
 
-    ansible.sudo = true
-    ansible.playbook = "provision.yml"
+      ansible.sudo = true
+      ansible.playbook = "provision.yml"
+    end
   end
 end

--- a/tests/vms/Vagrantfile.ubuntu15
+++ b/tests/vms/Vagrantfile.ubuntu15
@@ -8,39 +8,39 @@ Vagrant.configure(2) do | config |
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
-   config.vm.define "ubuntu15" do |ubuntu15|
+  config.vm.define "ubuntu15" do |ubuntu15|
     ubuntu15.vm.hostname = "ubuntu15.dev"
     ubuntu15.vm.box = "ubuntu/vivid64"
     ubuntu15.vm.network :private_network, ip: "192.168.40.6"
     ubuntu15.vm.network "forwarded_port", guest: 3000, host: 3003
-  end
 
-  # Ansible
-  config.vm.provision "ansible" do |ansible|
-    ansible.groups = {
-      "sensu_masters" => ["ubuntu15"],
-      "rabbitmq_servers" => ["ubuntu15"],
-      "redis_servers" => ["ubuntu15"],
-    }
+    # Ansible
+    config.vm.provision "ansible" do |ansible|
+      ansible.groups = {
+        "sensu_masters" => ["ubuntu15"],
+        "rabbitmq_servers" => ["ubuntu15"],
+        "redis_servers" => ["ubuntu15"],
+      }
 
-    ansible.extra_vars = {
-      dynamic_data_store: "data/dynamic",
-      rabbitmq_host: "192.168.40.6",
-      rabbitmq_server: true,
-      redis_host: "192.168.40.6",
-      redis_server: true,
-      sensu_api_host: "192.168.40.6",
-      sensu_api_user_name: "admin",
-      sensu_api_password: "admin",
-      sensu_include_plugins: false,
-      sensu_include_dashboard: true,
-      sensu_master: true,
-      uchiwa_dc_name: "vagrant",
-      uchiwa_user_name: "admin",
-      uchiwa_password: "admin",
-    }
+      ansible.extra_vars = {
+        dynamic_data_store: "data/dynamic",
+        rabbitmq_host: "192.168.40.6",
+        rabbitmq_server: true,
+        redis_host: "192.168.40.6",
+        redis_server: true,
+        sensu_api_host: "192.168.40.6",
+        sensu_api_user_name: "admin",
+        sensu_api_password: "admin",
+        sensu_include_plugins: false,
+        sensu_include_dashboard: true,
+        sensu_master: true,
+        uchiwa_dc_name: "vagrant",
+        uchiwa_user_name: "admin",
+        uchiwa_password: "admin",
+      }
 
-    ansible.sudo = true
-    ansible.playbook = "provision.yml"
+      ansible.sudo = true
+      ansible.playbook = "provision.yml"
+    end
   end
 end


### PR DESCRIPTION
Currently the Ansible provisioner gets shared among all the boxes, which leads to some weird behavior. I imagine as long as all boxes are up, everything works fine, since the configurations are pretty much the same and they'll be pointed towards at least one valid ip/port combo, but I'm working on a FreeBSD test VM, and I can't provision it at all with the way things are right now. I tested this against debian8 by itself and everything came up properly.
