### PR TITLE
Add 'become: False' for local_action

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -17,6 +17,7 @@
     when: sensu_remote_plugins > 0
 
   - name: Register available checks
+    become: False
     local_action: command ls {{ static_data_store }}/sensu/checks
     register: sensu_available_checks
     changed_when: false


### PR DESCRIPTION
Sometimes (as in my setup) there can be `become=True` in `ansible.cfg`:

```
[privilege_escalation]
become=True
```

This means that all tasks will tend to execute under 'sudo'. I think it is not valid for local_actions so it is better to explicitly avoid this when doing them.

In my case the role doesn't work as I also have 'become_ask_pass=False' and a password for sudo on my control machine.
