### PR TITLE
Use stdout_lines instead of stdout

### DIFF
--- a/docs/dynamic_checks.md
+++ b/docs/dynamic_checks.md
@@ -87,7 +87,7 @@ With this pair of plays, in the `tasks/plugins.yml` playbook:
       mode: 0755
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-    when: "'{{ item }}' in sensu_available_checks.stdout"
+    when: "'{{ item }}' in sensu_available_checks.stdout_lines"
     with_flattened:
       - group_names
     notify: restart sensu-client service

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -29,7 +29,7 @@
       mode: 0755
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-    when: "'{{ item }}' in sensu_available_checks.stdout"
+    when: "'{{ item }}' in sensu_available_checks.stdout_lines"
     with_flattened:
       - group_names
     notify: restart sensu-client service


### PR DESCRIPTION
I have a group name that's a single letter, and since that single letter occurs in the `ls`, it tries to copy a directory that isn't there:

```
failed: [host] (item=g) => {"failed": true, "item": "g", "msg": "could not find src=/home/smuth4/ansible/sensu/checks/g"}
```

This just fixes that.
