### PR TITLE
URL for sensu_ssl_tool.tar needs update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ sensu_ssl_client_key: "{{ sensu_ssl_tool_base_path }}/client/key.pem"
 sensu_ssl_server_cacert: "{{ sensu_ssl_tool_base_path }}/sensu_ca/cacert.pem"
 sensu_ssl_server_cert: "{{ sensu_ssl_tool_base_path }}/server/cert.pem"
 sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
+sensu_ssl_tool_version: "0.23"
 
 # Uchiwa properties
 uchiwa_dc_name: ~

--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -23,15 +23,15 @@
 
     - name: Fetch the ssl_certs tarball from sensuapp.org
       get_url:
-        url: http://sensuapp.org/docs/0.21/files/sensu_ssl_tool.tar
+        url: http://sensuapp.org/docs/{{ sensu_ssl_tool_version }}/files/sensu_ssl_tool.tar
         dest: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool.tar"
-  
+
     - name: Untar the ssl_certs tarball from sensuapp.org
       shell: tar xf sensu_ssl_tool.tar
       args:
         chdir: "{{ sensu_config_path }}/ssl_generation"
         creates: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool"
-  
+
     - name: Generate SSL certs
       command: "_ {{ sensu_config_path }}/ssl_generation/sensu_ssl_tool/ssl_certs.sh generate"
       args:


### PR DESCRIPTION
http://sensuapp.org/docs/0.21/files/sensu_ssl_tool.tar returns 404 file not found. Current version is 0.23
