### PR TITLE
Update all URLs to their latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The current version includes the following variables:
 |`sensu_deploy_redis`    | `true`    | Determines whether or not to use this role to deploy/configure redis |
 _Note: The above options are intended to provide users with flexibility. This allows the use of other roles for deployment of these services._
 
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_config_path` | `/etc/rabbitmq` | Path to the RabbitMQ configuration directory |
@@ -63,7 +63,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `rabbitmq_sensu_password` | sensu | Password for authentication with the RabbitMQ vhost |
 | `rabbitmq_sensu_vhost` | `/sensu` | Name of the RabbitMQ Sensu vhost |
 
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_host` | `"{{ groups['redis_servers'][0] }}"` | Hostname/IP address of the redis node |
@@ -74,7 +74,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `redis_pkg_state` | present | The state of the redis package (should be set to `present` or `latest`) |
 | `redis_port` | 6379 | The transmission port for redis communications |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_api_host` | `"{{ groups['sensu_masters'][0] }}"` | Hostname/IP address of the node running the Sensu API |
@@ -123,12 +123,12 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (specific to Linux systems) |
 
 ## Ubuntu
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_pkg_repo`   | `'ppa:rwky/redis'` | The PPA to use for installing redis from |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -139,13 +139,13 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/Ubuntu.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## Debian
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_pkg_repo`   | `'ppa:rwky/redis'` | The PPA to use for installing redis from |
 | `redis_service_name` | redis-server | The name of the redis service |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -156,7 +156,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/Debian.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## CentOS
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -165,19 +165,19 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/CentOS.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## SmartOS
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_config_path` | `/opt/local/etc/rabbitmq` | Path to the RabbitMQ configuration directory |
 | `rabbitmq_service_name` | rabbitmq | The name of the RabbitMQ service |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/opt/local/etc/sensu` | Path to the Sensu configuration directory |
 
 ## FreeBSD
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
@@ -185,7 +185,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_pkg_download_url` | `http://core.sensuapp.com/freebsd-unstable/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
 | `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_service_name` | `rabbitmq` | The name of the RabbitMQ service |

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
-| `sensu_pkg_version` | `0.23.0_1` | Version of Sensu to download and install |
-| `sensu_pkg_download_url` | `http://core.sensuapp.com/freebsd-unstable/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
+| `sensu_pkg_version` | `0.25.3_1` | Version of Sensu to download and install |
+| `sensu_pkg_download_url` | `http://sensu.global.ssl.fastly.net/freebsd/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
 | `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/docs/custom_client_config.md
+++ b/docs/custom_client_config.md
@@ -1,7 +1,7 @@
 # Custom Client Configuration
-When this Ansible role deploys the Sensu client configuration - defined in `client.json` in the Sensu configuration directory, it works out [subscriptions](https://sensuapp.org/docs/0.21/clients#definition-attributes) based on group membership within the Ansible inventory.
+When this Ansible role deploys the Sensu client configuration - defined in `client.json` in the Sensu configuration directory, it works out [subscriptions](https://sensuapp.org/docs/latest/reference/clients#client-subscriptions) based on group membership within the Ansible inventory.
 For example, if you have a `webservers` group within your Ansible inventory, any nodes listed in that group will automatically gain a subscription to `webservers` within Sensu.
-This is quite a powerful, convenient feature. It's coupled with the deployment of [checks](https://sensuapp.org/docs/0.18/checks). If you add a new webserver to your infrastructure, Sensu will dynamically pick it up, subscribe it to 'webservers', and deploy webserver checks, without you having to do anything other than add that node into the `webservers` group within your Ansible inventory. Instantaneous monitoring of your web services!
+This is quite a powerful, convenient feature. It's coupled with the deployment of [checks](https://sensuapp.org/docs/latest/guides/getting-started/intro-to-checks.html). If you add a new webserver to your infrastructure, Sensu will dynamically pick it up, subscribe it to 'webservers', and deploy webserver checks, without you having to do anything other than add that node into the `webservers` group within your Ansible inventory. Instantaneous monitoring of your web services!
 
 The above is all very nice and fancy, but, what if you want to define some other properties for a specific node, or override its subscriptions altogether?
 

--- a/docs/deploy_plugins.md
+++ b/docs/deploy_plugins.md
@@ -1,7 +1,7 @@
 # Deployment of Handlers, Filters, and Mutators
 _Note:_ _If you haven't familiarized yourself with the concept of the static data store please read_['_Dynamic check deployment'_](dynamic_checks.md)
 
-Deployment of [handlers](https://sensuapp.org/docs/0.21/handlers), [filters](https://sensuapp.org/docs/0.18/filters), and [mutators](https://sensuapp.org/docs/0.18/mutators) is handled by leveraging templates and other data placed in the static data store.
+Deployment of [handlers](https://sensuapp.org/docs/latest/reference/handlers), [filters](https://sensuapp.org/docs/latest/reference/filters), and [mutators](https://sensuapp.org/docs/latest/reference/mutators) is handled by leveraging templates and other data placed in the static data store.
 
 ## Static data store hierarchy with respect to handlers/filters/mutators
 To deploy your handlers, filters, and mutators, you'll need to have directories named after each under a directory called 'sensu' in your static data store:
@@ -28,13 +28,13 @@ data/static
 All three are deployed using Ansible's [template]() module. This allows the use of variables within your configurations, which can come in quite handy!
 
 Let's take a look at the stuff I've got for [Pushover](https://pushover.net/).
-First off, the [handler](https://sensuapp.org/docs/0.21/getting-started-with-handlers) json file `pushover_handler.json.j2`:
+First off, the [handler](https://sensuapp.org/docs/latest/guides/getting-started/intro-to-handlers) json file `pushover_handler.json.j2`:
 ``` json
 {
   "handlers": {
     "pushover": {
       "type": "pipe",
-      "command": "{{ sensu_config_path }}/plugins/pushover.rb",
+      "command": "{{ sensu_config_path }}/plugins/handler-pushover.rb",
       "timeout": 10,
       "severites": ["critical"]
     }
@@ -43,7 +43,7 @@ First off, the [handler](https://sensuapp.org/docs/0.21/getting-started-with-han
 ```
 This is a simple handler definition, registering the `pushover` handler, and its properties, so that it can be used for any checks that trigger it.
 
-[This particular handler](https://github.com/sensu/sensu-community-plugins/blob/master/handlers/notification/pushover.rb) needs a configuration file, `pushover.json.j2`:
+[This particular handler](https://github.com/sensu-plugins/sensu-plugins-pushover/blob/master/bin/handler-pushover.rb) needs a configuration file, `pushover.json.j2`:
 ``` json
 {
         "pushover": {
@@ -59,7 +59,7 @@ To use this, I have `sensu_pushover_userkey` & `sensu_pushover_token` defined in
 
 Not all handler's require a config file like this, but I figured I'd use this example to show how useful the templates can be.
 
-Finally, we have the actual handler script [`pushover.rb`](https://github.com/sensu/sensu-community-plugins/blob/master/handlers/notification/pushover.rb), which resides in the `handlers` directory.  
+Finally, we have the actual handler script [`handler-pushover.rb`](https://github.com/sensu-plugins/sensu-plugins-pushover/blob/master/bin/handler-pushover.rb), which resides in the `handlers` directory.
 
 
 These are all deployed when the role runs through the `tasks/plugins.yml` playbook, in particular these plays:

--- a/docs/dynamic_checks.md
+++ b/docs/dynamic_checks.md
@@ -1,5 +1,5 @@
 # Dynamic Check Deployment
-One of the awesome features of this role (if I do say so myself) is the deployment of Sensu [checks](https://sensuapp.org/docs/0.21/checks) on a dynamic basis. Deployment of which checks should be distributed to which nodes is determined from group membership within the Ansible inventory.
+One of the awesome features of this role (if I do say so myself) is the deployment of Sensu [checks](https://sensuapp.org/docs/latest/reference/checks) on a dynamic basis. Deployment of which checks should be distributed to which nodes is determined from group membership within the Ansible inventory.
 
 Have a group of webservers you need to monitor webservices on? Well, I'm sure you've bunched them together in your inventory under the `[webservers]` group, right? Or perhaps you only want to monitor disk space on your production systems; if they're a member of `[production]` within the inventory, you can do this easily.
 
@@ -69,7 +69,7 @@ tater.cmacr.ae
 web.cmacr.ae
 test.cmacr.ae
 ```
-Under these subdirectories, you can see [checks](https://sensuapp.org/docs/0.21/checks) that relate to the directory they're placed in.
+Under these subdirectories, you can see [checks](https://sensuapp.org/docs/latest/reference/checks) that relate to the directory they're placed in.
 The `webservers` subdirectory includes a `check_nginx.sh` script, whilst the `rabbitmq_servers` subdirectory has one that most likely checks for RabbitMQ problems (it does... trust me).  
 
 So how do these checks actually get deployed to their associated nodes?

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -9,7 +9,7 @@
 
 _Note: The above options are intended to provide users with flexibility. This allows the use of other roles for deployment of these services._
 
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_config_path` | `/etc/rabbitmq` | Path to the RabbitMQ configuration directory |
@@ -23,7 +23,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `rabbitmq_sensu_password` | sensu | Password for authentication with the RabbitMQ vhost |
 | `rabbitmq_sensu_vhost` | `/sensu` | Name of the RabbitMQ Sensu vhost |
 
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_host` | `"{{ groups['redis_servers'][0] }}"` | Hostname/IP address of the redis node |
@@ -33,7 +33,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `redis_pkg_state` | present | The state of the redis package (should be set to `present` or `latest`) |
 | `redis_port` | 6379 | The transmission port for redis communications |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_api_host` | `"{{ groups['sensu_masters'][0] }}"` | Hostname/IP address of the node running the Sensu API |
@@ -82,14 +82,14 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (specific to Linux systems) |
 
 ## Ubuntu
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_pkg_repo`   | `'ppa:rwky/redis'` | The PPA to use for installing redis from |
 | `redis_pkg_name` | redis-server |  The name of the redis package to install |
 
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -100,13 +100,13 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/Ubuntu.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## Debian
-### [redis Server Properties](https://sensuapp.org/docs/0.21/redis)
+### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `redis_pkg_repo`   | `'ppa:rwky/redis'` | The PPA to use for installing redis from |
 | `redis_service_name` | redis-server | The name of the redis service |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -117,7 +117,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/Debian.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## CentOS
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
@@ -126,19 +126,19 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_url`  | _See `vars/CentOS.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## SmartOS
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_config_path` | `/opt/local/etc/rabbitmq` | Path to the RabbitMQ configuration directory |
 | `rabbitmq_service_name` | rabbitmq | The name of the RabbitMQ service |
 
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/opt/local/etc/sensu` | Path to the Sensu configuration directory |
 
 ## FreeBSD
-### [Sensu Properties](https://sensuapp.org/docs/0.21/install-sensu)
+### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
@@ -146,7 +146,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_pkg_download_url` | `http://core.sensuapp.com/freebsd-unstable/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
 | `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
-### [RabbitMQ Server Properties](https://sensuapp.org/docs/0.21/rabbitmq)
+### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `rabbitmq_service_name` | `rabbitmq` | The name of the RabbitMQ service |

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -142,8 +142,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
-| `sensu_pkg_version` | `0.23.0_1` | Version of Sensu to download and install |
-| `sensu_pkg_download_url` | `http://core.sensuapp.com/freebsd-unstable/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
+| `sensu_pkg_version` | `0.25.3_1` | Version of Sensu to download and install |
+| `sensu_pkg_download_url` | `http://sensu.global.ssl.fastly.net/freebsd/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
 | `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,8 +4,8 @@
 
 # Sensu config/package properties
 sensu_config_path: /usr/local/etc/sensu
-sensu_pkg_version: 0.23.0_1
-sensu_pkg_download_url: https://core.sensuapp.com/freebsd-unstable/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz
+sensu_pkg_version: 0.25.3_1
+sensu_pkg_download_url: http://sensu.global.ssl.fastly.net/freebsd/10.0/amd64/sensu-{{ sensu_pkg_version }}.txz
 sensu_pkg_download_path: /root/sensu_latest.txz
 
 # RabbitMQ options


### PR DESCRIPTION
I fixed a bunch of documentation links that were out of date to something that's hopefully more future-proof, and changed the FreeBSD URL and default version to point to the latest package. I did a quick spot check of other URLs while I was at it, and rtfm.cmacr.ae is returning a 502 error, but I left the URL alone.
