### PR TITLE
unarchive_module requires copy

### DIFF
--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -29,6 +29,7 @@
     - name: Untar the ssl_certs tarball from sensuapp.org
       unarchive:
       args:
+        copy: no
         src: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool.tar"
         dest: "{{ sensu_config_path }}/ssl_generation/"
         creates: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool"


### PR DESCRIPTION
ansible unarchive module requires the option 'copy' to be set to 'no' if the file doesn't exist on local 'master'
