### PR TITLE
change debian GPG Key for RabbitMQ

### DIFF
--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -6,7 +6,7 @@
 
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
-      url: https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+      url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
       state: present
 
   - name: Ensure the RabbitMQ APT repo is present


### PR DESCRIPTION
RabbitMQ couldn't be installed due the missing gpg apt-key.
According to the rabbitMQ docs the correct key is here: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc

Tested with Debian 8.x, not sure if this has to be changed for ubuntu as well.
