### PR TITLE
Fix 'file or module does not exist' error

### DIFF
--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -29,6 +29,7 @@
     - name: Untar the ssl_certs tarball from sensuapp.org
       unarchive:
       args:
+        copy: no
         src: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool.tar"
         dest: "{{ sensu_config_path }}/ssl_generation/"
         creates: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool"


### PR DESCRIPTION
**Problem:** When running against remote host, the playbook failed with the following error:

```
TASK [cmacrae.sensu : Untar the ssl_certs tarball from sensuapp.org] ***********
fatal: [x.x.x.x]: FAILED! => {"failed": true, "msg": "file or module does not exist: /etc/sensu/ssl_generation/sensu_ssl_tool.tar"}
```

despite file being correctly placed by the previous task.

**Explanation:** By default Ansible's  [`unarchive` module](https://docs.ansible.com/ansible/unarchive_module.html) fetches the file from the local path: "_If true, the file is copied from local 'master' to the target machine, otherwise, the plugin will look for src archive at the target machine._"

**Solution:** Added `copy: no` argument to force Ansible to look where the file really is.
