### PR TITLE
replacing the obsolete repository

### DIFF
--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -3,7 +3,7 @@
 # Defaults are defined in vars/default.yml
 
 # redis server properties
-redis_pkg_repo: 'ppa:rwky/redis'
+redis_pkg_repo: 'ppa:chris-lea/redis-server'
 redis_pkg_name: redis-server
 
 # Sensu/Uchiwa user/group/service properties


### PR DESCRIPTION
according to the ppa site:

```
This ppa is no longer maintained. 
Please consider https://launchpad.net/~chris-lea/+archive/ubuntu/redis-server instead
```

Variable are updated accordingly
