### PR TITLE
Decouple server and Uchiwa API ports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ uchiwa_pkg_download_sha256sum: ~
 uchiwa_pkg_download_path: ~
 uchiwa_pkg_version: ~
 uchiwa_pkg_download_url: ~
+uchiwa_sensu_api_port: "{{ sensu_api_port }]"
 
 # Internal settings
 __bash_path: /bin/bash

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -84,6 +84,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_path` | _undefined_ | The path to fetch the Uchiwa package to (specific to Linux systems) |
 | `uchiwa_pkg_version` | _undefined_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
 | `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_sensu_api_port' | "{{ sensu_api_port }}" | Port for Uchiwa to communicate with the Sensu API. Change it if you have a load balancer/reverse proxy in front of the API servers listening on a different port than 4567. |
 
 ## Ubuntu
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)

--- a/templates/uchiwa_config.json.j2
+++ b/templates/uchiwa_config.json.j2
@@ -4,7 +4,7 @@
        "name": "{{ uchiwa_dc_name }}",
        "host": "{{ sensu_api_host }}",
        "ssl": {{ sensu_api_ssl }},
-       "port": {{ sensu_api_port }},
+       "port": {{ uchiwa_sensu_api_port }},
        "user": "{{ sensu_api_user_name }}",
        "pass": "{{ sensu_api_password }}",
        "path": "{{ sensu_api_uchiwa_path }}",


### PR DESCRIPTION
Otherwise it is very difficult to set up a reverse proxy with TLS in
front of the API service.

The default value stays the same as `sensu_api_port` to avoid breakage.