### PR TITLE
Fix server SSL configuration for non-default file names 

### DIFF
--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -15,11 +15,11 @@
 
   - name: Deploy the Sensu client SSL cert/key
     copy:
-      src: "{{ item }}"
+      src: "{{ item.src }}"
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-      dest: "{{ sensu_config_path }}/ssl"
+      dest: "{{ sensu_config_path }}/ssl/{{ item.dest }}"
     with_items:
-      - "{{ sensu_ssl_client_cert }}"
-      - "{{ sensu_ssl_client_key }}"
+      - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem}
+      - {src: "{{ sensu_ssl_client_key }}", dest: key.pem}
     notify: restart sensu-client service


### PR DESCRIPTION
SSL certificate files were copied with their original names, but the
configuration files always used the "default" names of cert.pem and
key.pem. Specify the destination basenames explicitly to avoid
mismatches.