### PR TITLE
Add option to copy SSL certificates with remote_src enabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,7 @@ sensu_client_subscriptions: "{{ group_names }}"
 
 # Sensu/RabbitMQ SSL certificate properties
 sensu_ssl_gen_certs: true
+sensu_ssl_deploy_remote_src: false
 sensu_master_config_path: "{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] | default('/etc/sensu') }}"
 sensu_ssl_tool_base_path: "{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"
 sensu_ssl_client_cert: "{{ sensu_ssl_tool_base_path }}/client/cert.pem"

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -64,6 +64,8 @@ _Note: The above options are intended to provide users with flexibility. This al
 sensu_ssl_gen_certs: true
 sensu_master_config_path: "{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] }}"
 sensu_ssl_tool_base_path: "{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"
+sensu_ssl_deploy_remote_src: false  # Copy certificates from paths in the destination host, not in the controller host.
+                                    # Useful if certificates are managed externally and already acquired before running this role.
 sensu_ssl_client_cert: "{{ sensu_ssl_tool_base_path }}/client/cert.pem"
 sensu_ssl_client_key: "{{ sensu_ssl_tool_base_path }}/client/key.pem"
 sensu_ssl_server_cacert: "{{ sensu_ssl_tool_base_path }}/sensu_ca/cacert.pem"

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -17,6 +17,7 @@
     copy:
       src: "{{ item }}"
       owner: "{{ sensu_user_name }}"
+      remote_src: "{{ sensu_ssl_deploy_remote_src }}"
       group: "{{ sensu_group_name }}"
       dest: "{{ sensu_config_path }}/ssl"
     with_items:


### PR DESCRIPTION
Allow copying certificates from paths are in the destination host, not
in the controller host.

Useful if certificates are managed externally and already acquired
before running this role.