### PR TITLE
Remove delegation from Sensu service handlers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,13 +13,3 @@ To log in, use `admin` as both the username & password.
 
 
 As support for other operating systems/distributions is written, they will be added as options for testing.
-
-## Caveats
-### Failing handlers
-It is expected that the following two handlers, triggered at the end of the test run will fail:  
-
-- `restart sensu-server service`
-- `restart sensu-api service`
-
-Both these handlers use the `delegate_to` directive, which does not play nice with Vagrant.  
-This __is__ expected to work in real deployments.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,9 +11,11 @@
 
   - name: restart sensu-server service
     service: name=sensu-server state=restarted
+    when: sensu_master
 
   - name: restart sensu-api service
     service: name=sensu-api state=restarted
+    when: sensu_master
 
   - name: restart sensu-client service
     service: name=sensu-client state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,11 +11,9 @@
 
   - name: restart sensu-server service
     service: name=sensu-server state=restarted
-    delegate_to: "{{ sensu_api_host }}"
 
   - name: restart sensu-api service
     service: name=sensu-api state=restarted
-    delegate_to: "{{ sensu_api_host }}"
 
   - name: restart sensu-client service
     service: name=sensu-client state=restarted

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -33,11 +33,3 @@
   - name: Install sensu from the retrieved txz package
     command: "pkg add {{ sensu_pkg_download_path }}"
     when: sensu_txz|changed
-
-  - name: Ensure the Sensu config directory is present
-    file:
-      dest: "{{ sensu_config_path }}/conf.d"
-      state: directory
-      recurse: true
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -16,14 +16,6 @@
       createhome: true
       state: present
 
-  - name: Ensure the Sensu config directory is present
-    file:
-      dest: "{{ sensu_config_path }}/conf.d"
-      state: directory
-      recurse: true
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-
   - name: Ensure Sensu dependencies are installed
     pkgin: name=build-essential,ruby21-base state=present
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -3,38 +3,6 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
-  - name: Ensure the Sensu config directory is present
-    file:
-      dest: "{{ sensu_config_path }}/conf.d"
-      state: directory
-      recurse: true
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-
-  - name: Deploy Sensu client RabbitMQ configuration
-    template:
-      dest: "{{ sensu_config_path }}/conf.d/rabbitmq.json"
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-      src: rabbitmq.json.j2
-    when: sensu_transport == "rabbitmq"
-
-  - name: Deploy Sensu client Redis configuration
-    template:
-      dest: "{{ sensu_config_path }}/conf.d/redis.json"
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-      src: sensu-redis.json.j2
-    when: sensu_transport == "redis"
-
-  - name: Deploy Sensu client transport configuration
-    template:
-      dest: "{{ sensu_config_path }}/conf.d/transport.json"
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-      src: transport.json.j2
-    notify: restart sensu-client service
-
   - name: Deploy Sensu client service configuration
     template:
       dest: "{{ sensu_config_path }}/conf.d/client.json"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,0 +1,46 @@
+---
+# tasks/common.yml: Deploy configurations common to client and server for Sensu
+
+  - include_vars: "{{ ansible_distribution }}.yml"
+
+  - name: Ensure the Sensu config directory is present
+    file:
+      dest: "{{ sensu_config_path }}/conf.d"
+      state: directory
+      recurse: true
+      owner: "{{ sensu_user_name }}"
+      group: "{{ sensu_group_name }}"
+
+  - name: Deploy Sensu Redis configuration
+    template:
+      dest: "{{ sensu_config_path }}/conf.d/redis.json"
+      owner: "{{ sensu_user_name }}"
+      group: "{{ sensu_group_name }}"
+      src: sensu-redis.json.j2
+    notify:
+      - restart sensu-server service
+      - restart sensu-api service
+      - restart sensu-client service
+
+  - name: Deploy Sensu RabbitMQ configuration
+    template:
+      dest: "{{ sensu_config_path }}/conf.d/rabbitmq.json"
+      owner: "{{ sensu_user_name }}"
+      group: "{{ sensu_group_name }}"
+      src: rabbitmq.json.j2
+    when: sensu_transport == "rabbitmq"
+    notify:
+      - restart sensu-server service
+      - restart sensu-api service
+      - restart sensu-client service
+
+  - name: Deploy Sensu transport configuration
+    template:
+      dest: "{{ sensu_config_path }}/conf.d/transport.json"
+      owner: "{{ sensu_user_name }}"
+      group: "{{ sensu_group_name }}"
+      src: transport.json.j2
+    notify:
+      - restart sensu-server service
+      - restart sensu-api service
+      - restart sensu-client service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
     when: rabbitmq_server
           and sensu_deploy_rabbitmq
 
+  - include: common.yml
+    tags: common
+
   - include: server.yml
     tags: server
     when: sensu_master

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -3,28 +3,12 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
-  - name: Ensure the Sensu config directory is present
-    file:
-      dest: "{{ sensu_config_path }}/conf.d"
-      state: directory
-      recurse: true
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-
   - name: Deploy Sensu server API configuration
     template:
       dest: "{{ sensu_config_path }}/conf.d/api.json"
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: sensu-api.json.j2
-    notify: restart sensu-api service
-
-  - name: Deploy Sensu redis configuration
-    template:
-      dest: "{{ sensu_config_path }}/conf.d/redis.json"
-      owner: "{{ sensu_user_name }}"
-      group: "{{ sensu_group_name }}"
-      src: sensu-redis.json.j2
     notify: restart sensu-api service
 
   - include: SmartOS/server.yml


### PR DESCRIPTION
Delegating tasks to `sensu_api_host` assumes some particular conditions,
such as there only being one API host, and that the value represents a
hostname under Ansible control, instead of load balancer address.

Remove it completely, as any masters under management should have their
services properly restarted when they reach the same tasks in their own
plays.