### PR TITLE
Allow customization of RabbitMQ configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `sensu_api_uchiwa_path` | `''` | Path to append to the Sensu API URI for Uchiwa communications |
 | `sensu_api_timeout` | 5000 | Value to set for the Sensu API timeout |
 | `sensu_client_config` | `client.json.j2` | Jinja2 template to use for node configuration of the Sensu Client service |
+| `sensu_rabbitmq_config` | `rabbitmq.json.j2` | Jinja2 template to use for RabbitMQ configuration |
 | `sensu_config_path` | `/etc/sensu` | Path to the Sensu configuration directory |
 | `sensu_gem_state` | present | State of the Sensu gem - can be set to `latest` to keep Sensu updated |
 | `sensu_plugin_gem_state` | present | State of the Sensu Plugins gem - can be set to `latest` to keep Sensu Plugins updated |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ sensu_api_password: secret
 sensu_api_uchiwa_path: ''
 sensu_api_timeout: 5000
 sensu_client_config: client.json.j2
+sensu_rabbitmq_config: rabbitmq.json.j2
 sensu_config_path: /etc/sensu
 sensu_pkg_state: present
 sensu_gem_state: present

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -27,7 +27,7 @@
       dest: "{{ sensu_config_path }}/conf.d/rabbitmq.json"
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-      src: rabbitmq.json.j2
+      src: "{{ sensu_rabbitmq_config }}"
     when: sensu_transport == "rabbitmq"
     notify:
       - restart sensu-server service

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -4,7 +4,7 @@
       "cert_chain_file": "{{ sensu_config_path }}/ssl/cert.pem",
       "private_key_file": "{{ sensu_config_path }}/ssl/key.pem"
     },
-"host": "{{ rabbitmq_host }}",
+    "host": "{{ rabbitmq_host }}",
     "port": {{ rabbitmq_port }},
     "vhost": "{{ rabbitmq_sensu_vhost }}",
     "user": "{{ rabbitmq_sensu_user_name }}",


### PR DESCRIPTION
This patch adds a variable `sensu_rabbitmq_config` which can be used to customize the `rabbitmq.json` file in case which you need to setup clustering, disable SSL or any other use cases.