### PR TITLE
moved uchiwa download variables to "default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _undefined_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched (specific to Linux systems) |
 | `uchiwa_pkg_download_path` | _undefined_ | The path to fetch the Uchiwa package to (specific to Linux systems) |
 | `uchiwa_pkg_version` | _undefined_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
 
 ## Ubuntu
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -140,7 +140,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -156,8 +156,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
 | `uchiwa_pkg_download_sha256sum` | _See `vars/Debian.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
-| `uchiwa_pkg_version` | _See `vars/Debian.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/Debian.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
@@ -165,8 +165,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `uchiwa_pkg_version` | _See `vars/CentOS.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/CentOS.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
 
 ## SmartOS
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _undefined_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched (specific to Linux systems) |
 | `uchiwa_pkg_download_path` | _undefined_ | The path to fetch the Uchiwa package to (specific to Linux systems) |
 | `uchiwa_pkg_version` | _undefined_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
+| `uchiwa_pkg_rpm_download_url` | _undefined_ | The URL of the Uchiwa package to fetch on rpm based distros |
+| `uchiwa_pkg_deb_download_url` | _undefined_ | The URL of the Uchiwa package to fetch on deb based distros |
 
 ## Ubuntu
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -140,7 +141,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
+| `uchiwa_pkg_deb_download_url` | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch on deb based distros |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -157,7 +158,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _See `vars/Debian.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
+| `uchiwa_pkg_deb_download_url` | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch on deb based distros |
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
@@ -166,7 +167,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
+| `uchiwa_pkg_rpm_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch on rpm based distros |
 
 ## SmartOS
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `uchiwa_pkg_download_sha256sum` | _See `vars/Ubuntu.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
+| `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
-| `uchiwa_pkg_version` | _See `vars/Ubuntu.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/Ubuntu.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,10 +75,10 @@ uchiwa_users:
     password: admin
 uchiwa_port: 3000
 uchiwa_refresh: 5
-uchiwa_pkg_download_sha256sum: ~
-uchiwa_pkg_download_path: ~
-uchiwa_pkg_version: ~
-uchiwa_pkg_download_url: ~
+uchiwa_pkg_download_sha256sum: 04d830e84159cc82b297ec9eb4333b8038b58ab77b12464163d7c5291bdda21d
+uchiwa_pkg_download_path: /root/uchiwa_latest.deb
+uchiwa_pkg_version: 0.14.2-1
+uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64.deb
 uchiwa_sensu_api_port: "{{ sensu_api_port }}"
 
 # Internal settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,7 +78,8 @@ uchiwa_refresh: 5
 uchiwa_pkg_download_sha256sum: 04d830e84159cc82b297ec9eb4333b8038b58ab77b12464163d7c5291bdda21d
 uchiwa_pkg_download_path: /root/uchiwa_latest.deb
 uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64
+uchiwa_pkg_deb_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64.deb
+uchiwa_pkg_rpm_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa-{{ uchiwa_pkg_version }}.x86_64.rpm
 uchiwa_sensu_api_port: "{{ sensu_api_port }}"
 
 # Internal settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,7 +78,7 @@ uchiwa_refresh: 5
 uchiwa_pkg_download_sha256sum: 04d830e84159cc82b297ec9eb4333b8038b58ab77b12464163d7c5291bdda21d
 uchiwa_pkg_download_path: /root/uchiwa_latest.deb
 uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64.deb
+uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64
 uchiwa_sensu_api_port: "{{ sensu_api_port }}"
 
 # Internal settings

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -101,10 +101,10 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `uchiwa_pkg_download_sha256sum` | _See `vars/Ubuntu.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
+| `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
-| `uchiwa_pkg_version` | _See `vars/Ubuntu.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/Ubuntu.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -118,7 +118,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `uchiwa_pkg_download_sha256sum` | _See `vars/Debian.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
+| `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `vars/Debian.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
 | `uchiwa_pkg_download_url`  | _See `vars/Debian.yml`_ | The URL of the Uchiwa package to fetch |

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -85,7 +85,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _undefined_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched (specific to Linux systems) |
 | `uchiwa_pkg_download_path` | _undefined_ | The path to fetch the Uchiwa package to (specific to Linux systems) |
 | `uchiwa_pkg_version` | _undefined_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
+| `uchiwa_pkg_rpm_download_url` | _undefined_ | The URL of the Uchiwa package to fetch on rpm based distros |
+| `uchiwa_pkg_deb_download_url` | _undefined_ | The URL of the Uchiwa package to fetch on deb based distros |
 | `uchiwa_sensu_api_port' | "{{ sensu_api_port }}" | Port for Uchiwa to communicate with the Sensu API. Change it if you have a load balancer/reverse proxy in front of the API servers listening on a different port than 4567. |
 
 ## Ubuntu
@@ -103,7 +104,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
-| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_deb_download_url` |  _See `defaults/main.yml`_  | The URL of the Uchiwa package to fetch on deb based distros |
 | `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)|
 
 ## Debian
@@ -121,7 +122,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `default/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)
+| `uchiwa_pkg_deb_download_url` |  _See `defaults/main.yml`_  | The URL of the Uchiwa package to fetch on deb based distros |
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
@@ -130,7 +131,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)
+| `uchiwa_pkg_rpm_download_url` | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch on rpm based distros |
 
 ## SmartOS
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -85,7 +85,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _undefined_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched (specific to Linux systems) |
 | `uchiwa_pkg_download_path` | _undefined_ | The path to fetch the Uchiwa package to (specific to Linux systems) |
 | `uchiwa_pkg_version` | _undefined_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url` | _undefined_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems) |
 | `uchiwa_sensu_api_port' | "{{ sensu_api_port }}" | Port for Uchiwa to communicate with the Sensu API. Change it if you have a load balancer/reverse proxy in front of the API servers listening on a different port than 4567. |
 
 ## Ubuntu
@@ -104,7 +104,7 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
 | `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)|
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -120,8 +120,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
 | `uchiwa_pkg_download_sha256sum` | _See `defaults/main.yml`_ | The SHA256 hash sum to use for verification of the Uchiwa package being fetched |
 | `uchiwa_pkg_download_path` | `/root/uchiwa_latest.deb` | The path to fetch the Uchiwa package to |
-| `uchiwa_pkg_version` | _See `vars/Debian.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/Debian.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `default/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
@@ -129,8 +129,8 @@ sensu_ssl_server_key: "{{ sensu_ssl_tool_base_path }}/server/key.pem"
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `uchiwa_pkg_version` | _See `vars/CentOS.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
-| `uchiwa_pkg_download_url`  | _See `vars/CentOS.yml`_ | The URL of the Uchiwa package to fetch |
+| `uchiwa_pkg_version` | _See `defaults/main.yml`_ | The version of the Uchiwa package to fetch (specific to Linux systems) |
+| `uchiwa_pkg_download_url`  | _See `defaults/main.yml`_ | The URL of the Uchiwa package to fetch (template will add .deb or .rpm - specific to Linux systems)
 
 ## SmartOS
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/tasks/Amazon/dashboard.yml
+++ b/tasks/Amazon/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Ensure Uchiwa is installed
     yum:
-      name: "{{ uchiwa_pkg_download_url }}"
+      name: "{{ uchiwa_pkg_download_url }}.rpm"
       state: present
 
   - name: Deploy Uchiwa config

--- a/tasks/Amazon/dashboard.yml
+++ b/tasks/Amazon/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Ensure Uchiwa is installed
     yum:
-      name: "{{ uchiwa_pkg_download_url }}.rpm"
+      name: "{{ uchiwa_pkg_rpm_download_url }}"
       state: present
 
   - name: Deploy Uchiwa config

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Ensure Uchiwa is installed
     yum:
-      name: "{{ uchiwa_pkg_download_url }}"
+      name: "{{ uchiwa_pkg_download_url }}.rpm"
       state: present
 
   - name: Deploy Uchiwa config

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Ensure Uchiwa is installed
     yum:
-      name: "{{ uchiwa_pkg_download_url }}.rpm"
+      name: "{{ uchiwa_pkg_rpm_download_url }}"
       state: present
 
   - name: Deploy Uchiwa config

--- a/tasks/Debian/dashboard.yml
+++ b/tasks/Debian/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Retrieve the Uchiwa deb package
     get_url:
-      url: "{{ uchiwa_pkg_download_url }}.deb"
+      url: "{{ uchiwa_pkg_deb_download_url }}"
       dest: "{{ uchiwa_pkg_download_path }}"
       sha256sum: "{{ uchiwa_pkg_download_sha256sum }}"
     register: uchiwa_deb

--- a/tasks/Debian/dashboard.yml
+++ b/tasks/Debian/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Retrieve the Uchiwa deb package
     get_url:
-      url: "{{ uchiwa_pkg_download_url }}"
+      url: "{{ uchiwa_pkg_download_url }}.deb"
       dest: "{{ uchiwa_pkg_download_path }}"
       sha256sum: "{{ uchiwa_pkg_download_sha256sum }}"
     register: uchiwa_deb

--- a/tasks/Ubuntu/dashboard.yml
+++ b/tasks/Ubuntu/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Retrieve the Uchiwa deb package
     get_url:
-      url: "{{ uchiwa_pkg_download_url }}"
+      url: "{{ uchiwa_pkg_download_url }}.deb"
       dest: "{{ uchiwa_pkg_download_path }}"
       sha256sum: "{{ uchiwa_pkg_download_sha256sum }}"
 

--- a/tasks/Ubuntu/dashboard.yml
+++ b/tasks/Ubuntu/dashboard.yml
@@ -6,7 +6,7 @@
 
   - name: Retrieve the Uchiwa deb package
     get_url:
-      url: "{{ uchiwa_pkg_download_url }}.deb"
+      url: "{{ uchiwa_pkg_deb_download_url }}"
       dest: "{{ uchiwa_pkg_download_path }}"
       sha256sum: "{{ uchiwa_pkg_download_sha256sum }}"
 

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -5,5 +5,3 @@
 # Sensu/Uchiwa user/group/service properties
 sensu_user_name: root
 sensu_group_name: root
-uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa-{{ uchiwa_pkg_version }}.x86_64.rpm

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -5,5 +5,3 @@
 # Sensu/Uchiwa user/group/service properties
 sensu_user_name: root
 sensu_group_name: root
-uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa-{{ uchiwa_pkg_version }}.x86_64.rpm

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,7 +9,3 @@ redis_service_name: redis-server
 # Sensu/Uchiwa user/group/service properties
 sensu_user_name: root
 sensu_group_name: root
-uchiwa_pkg_download_sha256sum: 04d830e84159cc82b297ec9eb4333b8038b58ab77b12464163d7c5291bdda21d
-uchiwa_pkg_download_path: /root/uchiwa_latest.deb
-uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64.deb

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -9,7 +9,3 @@ redis_pkg_name: redis-server
 # Sensu/Uchiwa user/group/service properties
 sensu_user_name: root
 sensu_group_name: root
-uchiwa_pkg_download_sha256sum: 04d830e84159cc82b297ec9eb4333b8038b58ab77b12464163d7c5291bdda21d
-uchiwa_pkg_download_path: /root/uchiwa_latest.deb
-uchiwa_pkg_version: 0.14.2-1
-uchiwa_pkg_download_url: http://dl.bintray.com/palourde/uchiwa/uchiwa_{{ uchiwa_pkg_version }}_amd64.deb


### PR DESCRIPTION
 moved uchiwa download variables to "default/main.yml" - to allow overriding of version in group_vars and inventory.  