### PR TITLE
Add toggle for SSL cert management

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 ### Sensu/RabbitMQ SSL certificate properties
 ``` yaml
 sensu_ssl_gen_certs: true
+sensu_ssl_manage_certs: true
 sensu_master_config_path: "{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] }}"
 sensu_ssl_tool_base_path: "{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"
 sensu_ssl_client_cert: "{{ sensu_ssl_tool_base_path }}/client/cert.pem"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ sensu_client_subscriptions: "{{ group_names }}"
 # Sensu/RabbitMQ SSL certificate properties
 sensu_ssl_gen_certs: true
 sensu_ssl_deploy_remote_src: false
+sensu_ssl_manage_certs: true
 sensu_master_config_path: "{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] | default('/etc/sensu') }}"
 sensu_ssl_tool_base_path: "{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"
 sensu_ssl_client_cert: "{{ sensu_ssl_tool_base_path }}/client/cert.pem"

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -62,6 +62,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 ### Sensu/RabbitMQ SSL certificate properties
 ``` yaml
 sensu_ssl_gen_certs: true
+sensu_ssl_manage_cert: true
 sensu_master_config_path: "{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] }}"
 sensu_ssl_tool_base_path: "{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"
 sensu_ssl_deploy_remote_src: false  # Copy certificates from paths in the destination host, not in the controller host.

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -18,6 +18,7 @@
       - restart rabbitmq service
       - restart sensu-api service
       - restart sensu-server service
+    when: sensu_ssl_manage_certs
 
   - name: Deploy RabbitMQ config
     template:

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -24,3 +24,4 @@
       - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem}
       - {src: "{{ sensu_ssl_client_key }}", dest: key.pem}
     notify: restart sensu-client service
+    when: sensu_ssl_manage_certs


### PR DESCRIPTION
For our environment, we prefer to manage the SSL certificates outside of this module entirely. This PR adds a simple toggle to support management of the SSL certs.