### PR TITLE
only create redis json when sensu_deploy_redis is true

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -17,6 +17,7 @@
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: sensu-redis.json.j2
+    when: sensu_deploy_redis
     notify:
       - restart sensu-server service
       - restart sensu-api service


### PR DESCRIPTION
Hi,

We're still having issues getting the sensu role to run through, and I believe it's because we don't have any redis config and don't want/need it, but the templating is still being triggered. This change fixes it for us.