### PR TITLE
Prevent 2 Ansible warnings in modern Ansible

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,7 +12,7 @@
 
   - name: Ensure local directories exist
     local_action: file state=directory dest="{{ static_data_store }}/sensu/{{ item }}"
-    sudo: no
+    become: no
     with_items:
       - checks
       - filters
@@ -38,7 +38,7 @@
       mode: 0755
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-    when: "sensu_available_checks is defined and '{{ item }}' in sensu_available_checks.stdout_lines"
+    when: "sensu_available_checks is defined and item in sensu_available_checks.stdout_lines"
     with_flattened:
       - "{{ group_names }}"
     notify: restart sensu-client service


### PR DESCRIPTION
- remove  usage of deprecated `sudo` directive (Ansible 2+)
- remove usage of jinja2 template delimiters in `when` statement (Ansible 2.3+)