### PR TITLE
Change default sensu_apt_key_url to use HTTPS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 # Sensu repo urls
 sensu_yum_repo_url: "http://repositories.sensuapp.org/yum/$releasever/$basearch/"
 sensu_apt_repo_url: "deb     http://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
-sensu_apt_key_url: "http://repositories.sensuapp.org/apt/pubkey.gpg"
+sensu_apt_key_url: "https://sensu.global.ssl.fastly.net/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"
 
 # Sensu service names


### PR DESCRIPTION
Similar to https://github.com/sensu/sensu-chef/issues/578, on Debian and
Ubuntu systems, Ansible is using HTTP to download the Public GPG key.
This change switches it to HTTPS by default.