### PR TITLE
Feature/use https for apt repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 # Sensu repo urls
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/"
 sensu_yum_key_url: "https://sensu.global.ssl.fastly.net/yum/pubkey.gpg"
-sensu_apt_repo_url: "deb     http://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
+sensu_apt_repo_url: "deb     https://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
 sensu_apt_key_url: "https://sensu.global.ssl.fastly.net/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"
 

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -21,4 +21,6 @@
       update_cache: true
 
   - name: Ensure Sensu is installed
-    apt: name={{ sensu_package }} state={{ sensu_pkg_state }}
+    apt: 
+      name: {{ sensu_package }} 
+      state: {{ sensu_pkg_state }}

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -4,6 +4,11 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
+  - name: Ensure apt-transport-https is installed
+    apt:
+      name: apt-transport-https
+      state: present
+
   - name: Ensure the Sensu APT repo GPG key is present
     apt_key:
       url: "{{ sensu_apt_key_url }}"

--- a/tasks/Ubuntu/main.yml
+++ b/tasks/Ubuntu/main.yml
@@ -5,7 +5,9 @@
   - include_vars: "{{ ansible_distribution }}.yml"
 
   - name: Ensure that https transport is ready
-    apt: name=apt-transport-https state=present
+    apt: 
+      name: apt-transport-https 
+      state: present
     
   - name: Ensure the Sensu APT repo GPG key is present
     apt_key:
@@ -19,4 +21,6 @@
       update_cache: true
 
   - name: Ensure Sensu is installed
-    apt: name={{ sensu_package }} state={{ sensu_pkg_state }}
+    apt: 
+      name: {{ sensu_package }}
+      state: {{ sensu_pkg_state }}


### PR DESCRIPTION
Related to https://github.com/sensu/sensu-ansible/pull/98, this PR will change the default `sensu_apt_repo_url` to HTTPS and updates the Debian tasks to ensure that `apt-transport-https` is installed (Ubuntu already had that section). Since I was in the area, I also cleaned up the main tasks to use the native YAML format. 