### PR TITLE
Feature/yum use https and gpg checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ sensu_enterprise_package: sensu-enterprise
 sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 
 # Sensu repo urls
-sensu_yum_repo_url: "http://repositories.sensuapp.org/yum/$releasever/$basearch/"
+sensu_yum_repo_url: "https://repositories.sensuapp.org/yum/$releasever/$basearch/"
 sensu_apt_repo_url: "deb     http://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
 sensu_apt_key_url: "http://repositories.sensuapp.org/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,8 @@ sensu_enterprise_package: sensu-enterprise
 sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 
 # Sensu repo urls
-sensu_yum_repo_url: "https://repositories.sensuapp.org/yum/$releasever/$basearch/"
+sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/"
+sensu_yum_key_url: "https://sensu.global.ssl.fastly.net/yum/pubkey.gpg"
 sensu_apt_repo_url: "deb     http://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
 sensu_apt_key_url: "http://repositories.sensuapp.org/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"

--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -9,7 +9,8 @@
       name: sensu
       description: The Sensu Core yum repository
       baseurl: "{{ sensu_yum_repo_url }}"
-      gpgcheck: no
+      gpgkey: "{{ sensu_yum_key_url }}"
+      gpgcheck: yes
       enabled: yes
 
   - name: Ensure Sensu is installed

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -14,7 +14,8 @@
       name: sensu
       description: The Sensu Core yum repository
       baseurl: "{{ sensu_yum_repo_url }}"
-      gpgcheck: no
+      gpgkey: "{{ sensu_yum_key_url }}"
+      gpgcheck: yes
       enabled: yes
 
   - name: Ensure that credential is supplied if installing Sensu Enterprise


### PR DESCRIPTION
Following suite of https://github.com/sensu/sensu-ansible/pull/98, this PR will enable the HTTPS version of `sensu_yum_repo_url` and adds `sensu_yum_key_url` and configures GPG package checking for the yum repos. 
