### PR TITLE
[doc] typo error for variable sensu_ssl_manage_cert(s)

### DIFF
--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -61,7 +61,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 
 ### Sensu/RabbitMQ SSL certificate properties
 | `sensu_ssl_gen_certs` | `true` | Determines when this role generates its own SSL certs |
-| `sensu_ssl_manage_cert` | `true` | Determines when this role manages deployment of the certs |
+| `sensu_ssl_manage_certs` | `true` | Determines when this role manages deployment of the certs |
 | `sensu_master_config_path` | `"{{ hostvars[groups['sensu_masters'][0]]['sensu_config_path'] }}"` | The configuration path of sensu on the first master host |
 | `sensu_ssl_tool_base_path` | `"{{ dynamic_data_store }}/{{ groups['sensu_masters'][0] }}{{ sensu_master_config_path }}/ssl_generation/sensu_ssl_tool"` ||
 | `sensu_ssl_deploy_remote_src` | `false` | Copy certificates from paths in the destination host, not in the controller host. Useful if certificates are managed externally and already acquired before running this role. |


### PR DESCRIPTION
variable: sensu_ssl_manage_cert is missing a "s"

it should be: sensu_ssl_manage_certs