### PR TITLE
Changed the ssl generation line to not include 'executable', as it is…

### DIFF
--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -23,11 +23,10 @@
         copy: no
 
     - name: Generate SSL certs
-      command: "_ {{ sensu_config_path }}/ssl_generation/sensu_ssl_tool/ssl_certs.sh generate"
+      command: "{{ __bash_path }} {{ sensu_config_path }}/ssl_generation/sensu_ssl_tool/ssl_certs.sh generate"
       args:
         chdir: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool"
         creates: "{{ sensu_config_path }}/ssl_generation/sensu_ssl_tool/server"
-        executable: "{{ __bash_path }}"
 
     when: sensu_master|bool
     become: true


### PR DESCRIPTION
… no longer supported in ansible 2.4

Solves issue #101 