### PR TITLE
Overwriting sensu_yum_repo_url for Amazon Linux

### DIFF
--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -4,6 +4,11 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
+  - name: Set epel_version override when AmazonLinux AMIv2
+    set_fact:
+      epel_version: 7
+    when: ansible_distribution_version == 'Candidate'
+
   - name: Ensure the Sensu Core Yum repo is present
     yum_repository:
       name: sensu

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -5,3 +5,6 @@
 # Sensu/Uchiwa user/group/service properties
 sensu_user_name: root
 sensu_group_name: root
+
+# Define repo url without $releasever
+sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -7,4 +7,6 @@ sensu_user_name: root
 sensu_group_name: root
 
 # Define repo url without $releasever
-sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"
+#Define epel version to 6 by default, change to 7 when using a version 2 AMI
+epel_version: 6
+sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/{{epel_version}}/$basearch/"


### PR DESCRIPTION
When installing the Sensu repo on Amazon Linux, this repo gets added to yum : https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/.
However, $releasever is defined as something like '2017.09' or 'latest', instead of 5, 6 or 7 on CentOS.

How to reproduce : Add the cmacrae.sensu to an Amazon Linux server, it will fail at the "Ensure Sensu is installed" task.
I'm not sure if hardcoding $releasever at '7' is the best solution, but I don't really see any other option as of now.