### PR TITLE
Feature/add travis automated tests and role sync 114

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+group: travis_lts
+services: docker
+env:
+  - distro: centos7
+  - distro: ubuntu1404
+  - distro: ubuntu1604
+  - distro: debian8
+  - distro: debian9
+before_install:
+  - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+script:
+  - export container_id=$(date +%s)
+  - export cleanup=false
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+  - ${PWD}/tests/test.sh
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-cmacrae.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/cmacrae/sensu/)
+# Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-cmacrae.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/cmacrae/sensu/) [![Build Status](https://travis-ci.org/sensu/sensu-ansible.svg?branch=master)](https://travis-ci.org/sensu/sensu-ansible)
 
 [![Join the chat at https://slack.sensu.io/](https://slack.sensu.io/badge.svg)](https://slack.sensu.io/)
 
@@ -14,7 +14,7 @@ This role deploys a full [Sensu](https://sensuapp.org) stack, a modern, open sou
 - Highly configurable
 
 ## Batteries included, but not imposed
-Along with deploying the Sensu Server, API and clients, this role can deploy a full stack: [RabbitMQ](http://www.rabbitmq.com/), [redis](http://redis.io), and the [Uchiwa dashboard](https://uchiwa.io/#/).  
+Along with deploying the Sensu Server, API and clients, this role can deploy a full stack: [RabbitMQ](http://www.rabbitmq.com/), [redis](http://redis.io), and the [Uchiwa dashboard](https://uchiwa.io/#/).
 However, if you want to rely on other roles/management methods to deploy/manage these services, [it's nice and easy to integrate this role](http://ansible-sensu.readthedocs.io/en/latest/integration/).
 
 ## Documentation [![Documentation](https://readthedocs.org/projects/ansible-sensu/badge/?version=latest)](http://ansible-sensu.readthedocs.io/en/latest/)
@@ -71,7 +71,7 @@ Created by [Calum MacRae](http://cmacr.ae)
 ### Contributors
 Stephen Muth - ([@smuth4](https://github.com/smuth4))
 
-Feel free to:  
-Contact me - [@calumacrae](https://twitter.com/calumacrae), [mailto:calum0macrae@gmail.com](calum0macrae@gmail.com)  
-[Raise an issue](https://github.com/cmacrae/ansible-sensu/issues)  
+Feel free to:
+Contact me - [@calumacrae](https://twitter.com/calumacrae), [mailto:calum0macrae@gmail.com](calum0macrae@gmail.com)
+[Raise an issue](https://github.com/cmacrae/ansible-sensu/issues)
 [Contribute](https://github.com/cmacrae/ansible-sensu/pulls)

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -8,6 +8,13 @@
     apt:
       name: apt-transport-https
       state: present
+      cache_valid_time: 3600
+      update_cache: true
+
+  - name: Ensure that gnupg is installed for apt_key
+    apt:
+      name: gnupg
+      state: present
 
   - name: Ensure the Sensu APT repo GPG key is present
     apt_key:

--- a/tasks/Ubuntu/main.yml
+++ b/tasks/Ubuntu/main.yml
@@ -5,10 +5,12 @@
   - include_vars: "{{ ansible_distribution }}.yml"
 
   - name: Ensure that https transport is ready
-    apt: 
-      name: apt-transport-https 
+    apt:
+      name: apt-transport-https
       state: present
-    
+      cache_valid_time: 3600
+      update_cache: true
+
   - name: Ensure the Sensu APT repo GPG key is present
     apt_key:
       url: "{{ sensu_apt_key_url }}"

--- a/templates/uchiwa_config.json.j2
+++ b/templates/uchiwa_config.json.j2
@@ -3,7 +3,7 @@
    {
        "name": "{{ uchiwa_dc_name }}",
        "host": "{{ sensu_api_host }}",
-       "ssl": {{ sensu_api_ssl | to_nice_json }},
+       "ssl": {{ sensu_api_ssl | lower }},
        "port": {{ uchiwa_sensu_api_port }},
        "user": "{{ sensu_api_user_name }}",
        "pass": "{{ sensu_api_password }}",

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  pre_tasks:
+    - name: Add localhost to sensu_masters group
+      add_host:
+        name: localhost
+        groups: sensu_masters
+      changed_when: false
+
+  roles:
+    - role: role_under_test
+      sensu_master: true
+      sensu_include_dashboard: true
+      rabbitmq_server: true
+      redis_server: true
+      rabbitmq_host: localhost
+      redis_host: localhost
+      sensu_api_host: localhost
+      # Workaround for https://github.com/geerlingguy/docker-ubuntu1604-ansible/issues/5
+      ansible_default_ipv4:
+        address: 127.0.0.1


### PR DESCRIPTION
This PR closes https://github.com/sensu/sensu-ansible/issues/114 and supersedes https://github.com/sensu/sensu-ansible/pull/115/ with some cleaner commits. 

Changes:
1. Build out base TravisCI config to make use of Jeff Geerling's ansible role testing shim: https://gist.github.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/ 
2. Configure `tests/test.yml` to actually work on deploying this role against CentOS 7, Ubuntu 14.04, Ubuntu 16.04, Debian 8 and Debian 9. I've purposely not added CentOS 6, as RabbitMQ doesn't support them any longer and I hit tons of issues attempting to get it to work. 
3. Fixup an syntax issue in the `uchiwa.json` config which results in the following when starting: 
```
{"timestamp":"2018-01-29T12:41:38.218583372Z","level":"fatal","message":"Error decoding file /etc/sensu/uchiwa.json: json: cannot unmarshal string into Go struct field SensuConfig.Ssl of type bool"}
```
4. Update Debian/Ubuntu to ensure that we've got an updated apt cache when trying to install apt-https-transport (resulted in build failures). 
5. Add the TravisCI build badge to the README. 


