### PR TITLE
Feature/debian ubuntu switch rabbit to bintray

### DIFF
--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -6,12 +6,13 @@
 
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
-      url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+      url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
       state: present
 
   - name: Ensure the RabbitMQ APT repo is present
     apt_repository:
-      repo: 'deb http://www.rabbitmq.com/debian/ testing main'
+      repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+      filename: rabbitmq
       state: present
       update_cache: true
 
@@ -19,4 +20,5 @@
     apt:
       name: rabbitmq-server
       state: "{{ rabbitmq_pkg_state }}"
+      cache_valid_time: 600
       update_cache: true

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -16,6 +16,18 @@
       state: present
       update_cache: true
 
+  - name: Ensure the Erlang APT repo GPG key is present
+    apt_key:
+      url: https://packages.erlang-solutions.com/debian/erlang_solutions.asc
+      state: present
+
+  - name: Ensure the Erlang APT repo is present
+    apt_repository:
+      repo: "deb https://packages.erlang-solutions.com/debian {{ ansible_distribution_release }} contrib"
+      filename: erlang
+      state: present
+      update_cache: true
+
   - name: Ensure RabbitMQ is installed
     apt:
       name: rabbitmq-server

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -6,12 +6,13 @@
 
   - name: Ensure the RabbitMQ APT repo GPG key is present
     apt_key:
-      url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+      url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
       state: present
 
   - name: Ensure the RabbitMQ APT repo is present
     apt_repository:
-      repo: 'deb http://www.rabbitmq.com/debian/ testing main'
+      repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+      filename: rabbitmq
       state: present
       update_cache: true
 
@@ -19,4 +20,5 @@
     apt:
       name: rabbitmq-server
       state: "{{ rabbitmq_pkg_state }}"
+      cache_valid_time: 600
       update_cache: true

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -16,6 +16,18 @@
       state: present
       update_cache: true
 
+  - name: Ensure the Erlang APT repo GPG key is present
+    apt_key:
+      url: https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+      state: present
+
+  - name: Ensure the Erlang APT repo is present
+    apt_repository:
+      repo: "deb https://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib"
+      filename: erlang
+      state: present
+      update_cache: true
+
   - name: Ensure RabbitMQ is installed
     apt:
       name: rabbitmq-server


### PR DESCRIPTION
This PR updates the repo location for RabbitMQ to using the latest Bintray mirror. Looking through https://www.rabbitmq.com/install-debian.html it seems like the hosted mirrors on rabbitmq.com are no longer listed(?). The main purpose here is that we're seeing a lot of flakyness in the builds when trying to pull from the rabbitmq.com repo's. Hopefully, bintray is more stable for the builds and for our users. 

This will also matchup Debian/Ubuntu with the current CentOS repo location (which was merged in https://github.com/sensu/sensu-ansible/pull/130/files) 