### PR TITLE
Explicitly configure file permissions to support restrictive umask configurations

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -9,6 +9,7 @@
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: "{{ sensu_client_config  }}"
+      mode: "0640"
     notify: restart sensu-client service
 
   - include: "{{ role_path }}/tasks/SmartOS/client.yml"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -9,6 +9,7 @@
       state: directory
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
+      mode: "0640"
 
   - name: Deploy Sensu Redis configuration
     template:
@@ -29,6 +30,7 @@
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: "{{ sensu_rabbitmq_config }}"
+      mode: "0640"
     when: sensu_transport == "rabbitmq"
           and sensu_deploy_rabbitmq_config
     notify:
@@ -43,6 +45,7 @@
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: transport.json.j2
+      mode: "0640"
     when: sensu_deploy_transport_config
     notify:
       - restart sensu-server service

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -9,7 +9,7 @@
       state: directory
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-      mode: "0640"
+      mode: "0750"
 
   - name: Deploy Sensu Redis configuration
     template:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -22,7 +22,7 @@
       - client_definitions
 
   - name: Ensure any remote plugins defined are present
-    shell: sensu-install -p {{ item }}
+    shell: umask 0022; sensu-install -p {{ item }}
     with_items: "{{ sensu_remote_plugins }}"
     changed_when: false
     when: sensu_remote_plugins > 0

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -24,7 +24,7 @@
       dest: "{{ sensu_config_path }}/ssl/{{ item.dest }}"
       mode: " {{ item.perm }}"
     with_items:
-      - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem , perm: "0644" }
+      - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem , perm: "0640" }
       - {src: "{{ sensu_ssl_client_key }}" , dest: key.pem  , perm: "0640" }
     notify: restart sensu-client service
     when: sensu_ssl_manage_certs

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -22,8 +22,9 @@
       remote_src: "{{ sensu_ssl_deploy_remote_src }}"
       group: "{{ sensu_group_name }}"
       dest: "{{ sensu_config_path }}/ssl/{{ item.dest }}"
+      mode: " {{ item.perm }}"
     with_items:
-      - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem}
-      - {src: "{{ sensu_ssl_client_key }}", dest: key.pem}
+      - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem , perm: "0644" }
+      - {src: "{{ sensu_ssl_client_key }}" , dest: key.pem  , perm: "0640" }
     notify: restart sensu-client service
     when: sensu_ssl_manage_certs

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -25,6 +25,6 @@
       mode: " {{ item.perm }}"
     with_items:
       - {src: "{{ sensu_ssl_client_cert }}", dest: cert.pem , perm: "0640" }
-      - {src: "{{ sensu_ssl_client_key }}" , dest: key.pem  , perm: "0640" }
+      - {src: "{{ sensu_ssl_client_key }}", dest: key.pem  , perm: "0640" }
     notify: restart sensu-client service
     when: sensu_ssl_manage_certs

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,10 +2,6 @@
 # vars/Amazon.yml: Variables for Amazon Linux AMI
 # Defaults are defined in defaults/main.yml
 
-# Sensu/Uchiwa user/group/service properties
-sensu_user_name: root
-sensu_group_name: root
-
 # Define repo url without $releasever
 #Define epel version to 6 by default, change to 7 when using a version 2 AMI
 epel_version: 6

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -3,8 +3,6 @@
 # Defaults are defined in defaults/main.yml
 
 # Sensu/Uchiwa user/group/service properties
-sensu_user_name: root
-sensu_group_name: root
 _sensu_pkg_version: '0.29.0'
 
 #Set this to false to disable the EPEL repo installation

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,7 +5,3 @@
 # redis server properties
 redis_pkg_name: redis-server
 redis_service_name: redis-server
-
-# Sensu/Uchiwa user/group/service properties
-sensu_user_name: root
-sensu_group_name: root

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -5,7 +5,3 @@
 # redis server properties
 redis_pkg_name: redis-server
 redis_service_name: redis-server
-
-# Sensu/Uchiwa user/group/service properties
-sensu_user_name: root
-sensu_group_name: root


### PR DESCRIPTION
Originally from https://github.com/sensu/sensu-ansible/pull/127 

I've nuked the setup of `root` for the user/group that sensu config directories/files are getting owned to and restored them back to the global default of `sensu` this aligns with:

Puppet: https://github.com/sensu/sensu-puppet/blob/master/manifests/init.pp#L491
Chef: https://github.com/sensu/sensu-chef/blob/develop/attributes/default.rb#L2-L3