### PR TITLE
Update CHANGELOG for release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [1.3.0] - 2018-02-04
+## [2.0.0] - 2018-02-06
 ### Added
 - Initial support for OpenBSD! (@smbambling)
 - Ubuntu now get's `apt-transport-https` installed to support HTTPS repos. (@kevit)
 - Default to HTTPS APT repo's.  @jaredledvina
-- Ubuntu - Redis now always binds to `0.0.0.0` to ensure it's accessible. (@tculp)
 - Allow for configuring when a node gets the `sensu-client` config file. (@tculp)
-- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
 - Allow for deploying client definitions based on groups. (@tculp)
 - Default to HTTPS Yum repo's and install the Yum key for package signing validation via HTTPS.  (@jaredledvina)
 - Used HTTPS for APT key.  (@jaredledvina)
@@ -28,6 +26,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Switched from Gitter to `#ansible` in the Sensu Community Slack. (@grepory)
 - Bumped SSL tools version to 1.2 by default. (@marji)
 - Update 'Generate SSL Certs' to support Ansible 2.4. (@tculp)
+
+### Fixed
+- Ubuntu - Redis now always binds to `0.0.0.0` to match other distro's configurgation and to ensure it's accessible. (@tculp)
+
+### Breaking Change
+- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
+  `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.
+  See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
 
 ## [1.2.0] - 2017-05-13
 ### Added
@@ -59,7 +65,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 First tagged release, starting at 1.0.0 since the project can be considered stable at this point.
 
-[Unreleased]: https://github.com/sensu/sensu-ansible/compare/1.3.0...HEAD
-[1.3.0]: https://github.com/sensu/sensu-ansible/compare/1.2.0...1.3.0
+[Unreleased]: https://github.com/sensu/sensu-ansible/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/sensu/sensu-ansible/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/sensu/sensu-ansible/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/sensu/sensu-ansible/compare/1.0.0...1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ## [2.0.0] - 2018-02-06
+### Breaking Change
+- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
+  `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.
+  See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
+- Redis on Ubuntu will now be configured to bind to `0.0.0.0` to ensure accessiblity and to match the other supported OS configurations (@tculp)
+
+
 ### Added
 - Initial support for OpenBSD! (@smbambling)
 - Ubuntu now get's `apt-transport-https` installed to support HTTPS repos. (@kevit)
-- Default to HTTPS APT repo's.  @jaredledvina
+- Default to HTTPS APT repos.  @jaredledvina
 - Allow for configuring when a node gets the `sensu-client` config file. (@tculp)
 - Allow for deploying client definitions based on groups. (@tculp)
 - Default to HTTPS Yum repo's and install the Yum key for package signing validation via HTTPS.  (@jaredledvina)
 - Used HTTPS for APT key.  (@jaredledvina)
-- Amazon Linux now get's proper yum repo and supports Amazon Linux 2. (@romainrbr)
+- Amazon Linux has proper yum repo configured and supports Amazon Linux 2. (@romainrbr)
 - Yum based distros now get EPEL to support installing a newer and supported version of RabbitMQ. (@romainrbr)
 - CentOS now supports using Bintray mirrors for installing RabbitMQ to work around Erlang issues with older versions. (@romainrbr)
-- All PR's are now required to pass TravisCI tests.  (@jaredledvina)
+- All PRs are now required to pass TravisCI integrations tests.  (@jaredledvina)
 - Ensure that we configure the `mode` and `umask` for files to work in a more restrictive environment. (@roumano)
 - Debian and Ubuntu switch to Bintray for RabbitMQ to match yum distros. (@jaredledvina)
 
@@ -26,14 +33,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Switched from Gitter to `#ansible` in the Sensu Community Slack. (@grepory)
 - Bumped SSL tools version to 1.2 by default. (@marji)
 - Update 'Generate SSL Certs' to support Ansible 2.4. (@tculp)
-
-### Fixed
-- Ubuntu - Redis now always binds to `0.0.0.0` to match other distro's configurgation and to ensure it's accessible. (@tculp)
-
-### Breaking Change
-- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
-  `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.
-  See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
 
 ## [1.2.0] - 2017-05-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,35 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## 1.2.0 2017-05-13
+## [Unreleased]
+
+## [1.3.0] - 2018-02-04
+### Added
+- Initial support for OpenBSD! (@smbambling)
+- Ubuntu now get's `apt-transport-https` installed to support HTTPS repos. (@kevit)
+- Default to HTTPS APT repo's.  @jaredledvina
+- Ubuntu - Redis now always binds to `0.0.0.0` to ensure it's accessible. (@tculp)
+- Allow for configuring when a node gets the `sensu-client` config file. (@tculp)
+- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
+- Allow for deploying client definitions based on groups. (@tculp)
+- Default to HTTPS Yum repo's and install the Yum key for package signing validation via HTTPS.  (@jaredledvina)
+- Used HTTPS for APT key.  (@jaredledvina)
+- Amazon Linux now get's proper yum repo and supports Amazon Linux 2. (@romainrbr)
+- Yum based distros now get EPEL to support installing a newer and supported version of RabbitMQ. (@romainrbr)
+- CentOS now supports using Bintray mirrors for installing RabbitMQ to work around Erlang issues with older versions. (@romainrbr)
+- All PR's are now required to pass TravisCI tests.  (@jaredledvina)
+- Ensure that we configure the `mode` and `umask` for files to work in a more restrictive environment. (@roumano)
+- Debian and Ubuntu switch to Bintray for RabbitMQ to match yum distros. (@jaredledvina)
+
+### Changed
+- Switched from Gitter to `#ansible` in the Sensu Community Slack. (@grepory)
+- Bumped SSL tools version to 1.2 by default. (@marji)
+- Update 'Generate SSL Certs' to support Ansible 2.4. (@tculp)
+
+## [1.2.0] - 2017-05-13
 ### Added
 - RedHat support
 - Sensu enterprise support
@@ -19,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Make sure any local directories that are assumed to exist actually do
 
-## 1.1.0 2017-04-03
+## [1.1.0] - 2017-04-03
 ### Added
 - Toggle for SSL cert management
 
@@ -29,6 +55,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Fixed behaivor changed by recent versions of Ansible
 
-## 1.0.0 2017-02-14
+## 1.0.0 - 2017-02-14
 
 First tagged release, starting at 1.0.0 since the project can be considered stable at this point.
+
+[Unreleased]: https://github.com/sensu/sensu-ansible/compare/1.3.0...HEAD
+[1.3.0]: https://github.com/sensu/sensu-ansible/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/sensu/sensu-ansible/compare/1.1.0...1.2.0
+[1.1.0]: https://github.com/sensu/sensu-ansible/compare/1.0.0...1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [2.0.0] - 2018-02-06
+## [2.0.0] - 2018-02-07
 ### Breaking Change
 - Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
   `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.
   See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
 - Redis on Ubuntu will now be configured to bind to `0.0.0.0` to ensure accessiblity and to match the other supported OS configurations (@tculp)
-
+- Updated the supported Ansible version to the last two stable releases (currently that's Ansible 2.3 and 2.4) (@jaredledvina)
+  Please note that we have not explicitly broken support for running this role on versions of Ansible <2.3. However, we will only
+  be activly supporting the last two stable Ansible releases to reduce the maintenance burden.
 
 ### Added
 - Initial support for OpenBSD! (@smbambling)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [2.0.0] - 2018-02-07
 ### Breaking Change
-- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp)
-  `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.
-  See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
-- Redis on Ubuntu will now be configured to bind to `0.0.0.0` to ensure accessiblity and to match the other supported OS configurations (@tculp)
-- Updated the supported Ansible version to the last two stable releases (currently that's Ansible 2.3 and 2.4) (@jaredledvina)
-  Please note that we have not explicitly broken support for running this role on versions of Ansible <2.3. However, we will only
-  be activly supporting the last two stable Ansible releases to reduce the maintenance burden.
+- Split up the variables used to determine if a host gets rabbitmq/redis for more flexibility in deployments. (@tculp) `sensu_deploy_rabbitmq` and `sensu_deploy_redis` are now `sensu_deploy_rabbitmq_server` and `sensu_deploy_redis_server` respectively.  See the [role variable documentation](https://github.com/sensu/sensu-ansible/blob/master/docs/role_variables.md) for details on the parameters.
+- Redis on Ubuntu will now be configured to bind to `0.0.0.0` to ensure accessiblity and to match the other supported OS configurations. (@tculp)
+- Updated the supported Ansible version to the last two stable releases (currently that's Ansible 2.3 and 2.4). (@jaredledvina) Please note that we have not explicitly broken support for running this role on versions of Ansible <2.3. However, we will only be actively supporting the last two stable Ansible releases to reduce the maintenance burden.
 
 ### Added
 - Initial support for OpenBSD! (@smbambling)


### PR DESCRIPTION
This PR updates the CHANGELOG for soon-to-be-released 1.3.0 version. I went through the many PR's/changes that have been merged in since 1.2.0. Nothing appears to actually have been breaking but, I'll be adding a notice in the actual release for folks to ensure they test this version prior to just deploying it. Now that we've got the issues/PR's under control w/ integration tests, these releases should be much easier and faster to cut going forward. 

Based on https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md 

@mbbroberg / @majormoses  as my first _real_ changelog update, how's this look to you? 