### PR TITLE
Add fedora as OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - distro: ubuntu1604
   - distro: debian8
   - distro: debian9
+  - distro: fedora27
 before_install:
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- `vars/Fedora.yml`, `tasks/Fedora/main.yml`: Add Fedora as a client OS. Tested on Fedora 25, but should work on newer releases as well.
+
 ## [2.1.0]
 ### Fixed
 - `defaults/main.yaml`,`tasks/plugins.yml`: Fix Python 3.X compatability issue when checking the contents of sensu_remote_plugins. (@danragnar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added
-- `vars/Fedora.yml`, `tasks/Fedora/main.yml`: Add Fedora as a client OS. Tested on Fedora 25, but should work on newer releases as well.
+- Fedora support. Tested in the wild on Fedora 25 as a client and Fedora 27 on the test suite as both master and client.
+    - `tasks/Fedora/redis.yml`, `tasks/Fedora/rabbit.yml`: Based on CentOS equivalents but with dnf module instead of yum
+    - `tasks/Fedora/main.yml`, `tasks/Fedora/dashboard.yml`: links to Centos files
+    - `vars/Fedora.yml`: vars for Fedora
+
+### Changed
+- `tasks/CentOS/dashboard.yml`, `tasks/CentOS/main.yml`: Use generic package module to support Fedora
 
 ## [2.1.0]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- `vars/Fedora.yml`, `tasks/Fedora/main.yml`: Add Fedora as a client OS. Tested on Fedora 25, but should work on newer releases as well.
 
 ## [2.1.0]
 ### Fixed

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -5,13 +5,13 @@
   - include_vars: "{{ ansible_distribution }}.yml"
 
   - name: Ensure Uchiwa is installed
-    yum:
+    package:
       name: uchiwa
       state: present
     when: not se_enterprise
 
   - name: Ensure Sensu Enterprise Dashboard is installed
-    yum:
+    package:
       name: "{{ sensu_enterprise_dashboard_package }}"
       state: present
     when: se_enterprise

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -55,12 +55,12 @@
     when: se_enterprise
 
   - name: Ensure Sensu is installed
-    yum:
+    package:
       name: "{{sensu_package }}-{{sensu_pkg_version}}"
       state: "{{ sensu_pkg_state }}"
 
   - name: Ensure Sensu Enterprise is installed
-    yum:
+    package:
       name={{ sensu_enterprise_package }}
       state={{ sensu_pkg_state }}
     when: se_enterprise

--- a/tasks/Fedora/dashboard.yml
+++ b/tasks/Fedora/dashboard.yml
@@ -1,0 +1,1 @@
+../CentOS/dashboard.yml

--- a/tasks/Fedora/main.yml
+++ b/tasks/Fedora/main.yml
@@ -1,0 +1,1 @@
+../CentOS/main.yml

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -1,0 +1,35 @@
+---
+# tasks/CentOS/rabbit.yml: Deploy RabbitMQ
+# Specific to CentOS
+
+  - include_vars: "{{ ansible_distribution }}.yml"
+
+  - name: Add RabbitMQ's repo
+    yum_repository:
+      name: rabbitmq
+      description: rabbitmq
+      baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/{{ansible_distribution_major_version}}"
+      gpgcheck: yes
+      gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+      repo_gpgcheck: no
+
+  - name: Add RabbitMQ's Erlang repo
+    yum_repository:
+      name: rabbitmq-erlang
+      description: rabbitmq-erlang
+      baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/{{ansible_distribution_major_version}}"
+      gpgcheck: yes
+      gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+      repo_gpgcheck: no
+
+  - name: Ensure Erlang & RabbitMQ are installed
+    yum:
+      name:
+        - erlang
+        - rabbitmq-server
+      state: present
+      enablerepo: rabbitmq,rabbitmq-erlang
+      disablerepo: epel
+
+
+

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -8,7 +8,7 @@
     yum_repository:
       name: rabbitmq
       description: rabbitmq
-      baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/{{ansible_distribution_major_version}}"
+      baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/7"
       gpgcheck: yes
       gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
       repo_gpgcheck: no
@@ -17,7 +17,7 @@
     yum_repository:
       name: rabbitmq-erlang
       description: rabbitmq-erlang
-      baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/{{ansible_distribution_major_version}}"
+      baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/7"
       gpgcheck: yes
       gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
       repo_gpgcheck: no
@@ -29,7 +29,6 @@
         - rabbitmq-server
       state: present
       enablerepo: rabbitmq,rabbitmq-erlang
-      disablerepo: epel
 
 
 

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -1,6 +1,6 @@
 ---
-# tasks/CentOS/rabbit.yml: Deploy RabbitMQ
-# Specific to CentOS
+# tasks/Fedora/rabbit.yml: Deploy RabbitMQ
+# Specific to Fedora
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
@@ -23,7 +23,7 @@
       repo_gpgcheck: no
 
   - name: Ensure Erlang & RabbitMQ are installed
-    yum:
+    dnf:
       name:
         - erlang
         - rabbitmq-server

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -1,0 +1,1 @@
+../CentOS/redis.yml

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -1,1 +1,23 @@
-../CentOS/redis.yml
+---
+# tasks/Fedora/redis.yml: Deploy redis
+# Specific to Fedora
+
+  - include_vars: "{{ ansible_distribution }}.yml"
+
+  - name: Install EPEL repo
+    dnf:
+      name: epel-release
+      state: present
+    when: enable_epel_repo
+
+  - name: Ensure redis is installed
+    dnf:
+      name: "{{ redis_pkg_name }}"
+      state: "{{ redis_pkg_state }}"
+      enablerepo: "{{ centos_repository }}"
+
+  - name: Ensure redis binds to accessible IP
+    lineinfile:
+      dest: /etc/redis.conf
+      regexp: '^bind'
+      line: 'bind 0.0.0.0'

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -4,17 +4,10 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
-  - name: Install EPEL repo
-    dnf:
-      name: epel-release
-      state: present
-    when: enable_epel_repo
-
   - name: Ensure redis is installed
     dnf:
       name: "{{ redis_pkg_name }}"
       state: "{{ redis_pkg_state }}"
-      enablerepo: "{{ centos_repository }}"
 
   - name: Ensure redis binds to accessible IP
     lineinfile:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -5,8 +5,5 @@
 # Sensu/Uchiwa user/group/service properties
 _sensu_pkg_version: '1.2.1'
 
-#Set this to false to disable the EPEL repo installation
-enable_epel_repo: true
-
 #RH/Centos 7 version works for Fedora 25 as a client
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,12 @@
+---
+# vars/Fedora.yml: Variables for Fedora
+# Defaults are defined in defaults/main.yml
+
+# Sensu/Uchiwa user/group/service properties
+_sensu_pkg_version: '1.2.1'
+
+#Set this to false to disable the EPEL repo installation
+enable_epel_repo: true
+
+#RH/Centos 7 version works for Fedora 25 as a client
+sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"


### PR DESCRIPTION
This PR allows Fedora to be used in Sensu. At first I only added it as a client OS, but since testing only for client parts seems inconvenient, I added it as a "master" candidate as well as well as a distro in the travis file. I have only tested it here as a client OS, and that's on Fedora 25, so lets see if the tests go through... 