### PR TITLE
Allowing keepalive and safe_mode attributes to be configured in client.json + fixing yumrep for CentOS/RH 5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,11 @@ sensu_remote_plugins: []
 sensu_transport: rabbitmq
 sensu_client_name: "{{ ansible_hostname }}"
 sensu_client_subscriptions: "{{ group_names }}"
+sensu_client_keepalive_handlers:
+  - default
+sensu_client_keepalive_threshold_warning: 120
+sensu_client_keepalive_threshold_critical: 180
+sensu_client_safe_mode: false
 sensu_deploy_rabbitmq_config: true
 sensu_deploy_redis_config: true
 sensu_deploy_transport_config: true

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -15,7 +15,10 @@
       description: The Sensu Core yum repository
       baseurl: "{{ sensu_yum_repo_url }}"
       gpgkey: "{{ sensu_yum_key_url }}"
-      gpgcheck: yes
+      gpgcheck: "{{ (
+        (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux') and
+        ansible_distribution_major_version == '5'
+        ) | ternary('no', 'yes') }}"
       enabled: yes
 
   - name: Ensure that credential is supplied if installing Sensu Enterprise

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -2,6 +2,14 @@
   "client": {
     "name": "{{ sensu_client_name }}",
     "address": "{{ ansible_default_ipv4['address'] }}",
-    "subscriptions": {{ sensu_client_subscriptions | to_nice_json }}
+    "subscriptions": {{ sensu_client_subscriptions | to_nice_json(indent=6) }},
+    "keepalive": {
+      "handlers": {{ sensu_client_keepalive_handlers | to_nice_json(indent=8) }},
+      "thresholds": {
+        "warning": {{ sensu_client_keepalive_threshold_warning }},
+        "critical": {{ sensu_client_keepalive_threshold_critical }}
+        }
+    },
+    "safe_mode": {{ sensu_client_safe_mode | bool | lower }}
   }
 }


### PR DESCRIPTION
Updates the client.json template to allow setting keepalive attributes for handlers, warning/critical threshold. These values defaults in the role to the Sensu application defaults

Disables gpgcheck in the YUM repository for CentOS/RH 5 nodes as they are not signed in in the Sensu YUM repositories. This code still maintains gpgcheck enabled for all other major versions