### PR TITLE
Adding client.json keepalive/safe_mode attributes + dir/file permission fixes + CentOS 5 gpgcheck disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Issue that prevented older OS such as CentOS 5 from installing the Sensu RPM package as they are unsigned (@smbambling)
+- Security issue with redis.json being world readable, as it can contain sensitive information (@smbambling)
+- Issue with conf.d that limited access and prevent automated tests from passing (@smbambling)
+
+### Added
+- Support for keepalive attributes: handlers and thresholds (warning/critical) in client.json (@smbambling)
+- Support for managing safe_mode in client.json (@smbambling)
 
 ## [2.2.0] - 2018-02-22
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,11 @@ sensu_remote_plugins: []
 sensu_transport: rabbitmq
 sensu_client_name: "{{ ansible_hostname }}"
 sensu_client_subscriptions: "{{ group_names }}"
+sensu_client_keepalive_handlers:
+  - default
+sensu_client_keepalive_threshold_warning: 120
+sensu_client_keepalive_threshold_critical: 180
+sensu_client_safe_mode: false
 sensu_deploy_rabbitmq_config: true
 sensu_deploy_redis_config: true
 sensu_deploy_transport_config: true

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -15,7 +15,10 @@
       description: The Sensu Core yum repository
       baseurl: "{{ sensu_yum_repo_url }}"
       gpgkey: "{{ sensu_yum_key_url }}"
-      gpgcheck: yes
+      gpgcheck: "{{ (
+        (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux') and
+        ansible_distribution_major_version == '5'
+        ) | ternary('no', 'yes') }}"
       enabled: yes
 
   - name: Ensure that credential is supplied if installing Sensu Enterprise

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -9,7 +9,7 @@
       state: directory
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
-      mode: "0750"
+      mode: "0555"
 
   - name: Deploy Sensu Redis configuration
     template:
@@ -17,6 +17,7 @@
       owner: "{{ sensu_user_name }}"
       group: "{{ sensu_group_name }}"
       src: "{{ sensu_redis_config }}"
+      mode: "0640"
     when: sensu_deploy_redis_config
     notify:
       - restart sensu-server service

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -2,6 +2,14 @@
   "client": {
     "name": "{{ sensu_client_name }}",
     "address": "{{ ansible_default_ipv4['address'] }}",
-    "subscriptions": {{ sensu_client_subscriptions | to_nice_json }}
+    "subscriptions": {{ sensu_client_subscriptions | to_nice_json(indent=6) }},
+    "keepalive": {
+      "handlers": {{ sensu_client_keepalive_handlers | to_nice_json(indent=8) }},
+      "thresholds": {
+        "warning": {{ sensu_client_keepalive_threshold_warning }},
+        "critical": {{ sensu_client_keepalive_threshold_critical }}
+        }
+    },
+    "safe_mode": {{ sensu_client_safe_mode | bool | lower }}
   }
 }


### PR DESCRIPTION
adding client.json additions for safe_mode, keepalive attributes
setting CentOS/RH 5 legacy repositories gpgcheck to disabled
fixing dir/file permissions, redis should not be world readable it can contain a password