### PR TITLE
Feature/simply install sensu stop pinning ancient versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Deprecated `sensu_pkg_version` for Redhat, Fedora, CentOS, and FreeBSD. To pin going forward across all operating systems, simply append the Sensu version to `sensu_package`. For example, `sensu_package: sensu-1.3.3` will ensure that only Sensu 1.3.3 is ever installed. (@jaredledvina)
+- Ensure that on first install we install the latest stable Sensu release (@jaredledvina)
+- Document `sensu_pkg_state`. If you'd like to ensure the latest stable release is always installed, simply leave `sensu_package` to the default `sensu` and change `sensu_pkg_state` to `latest`. (@jaredledvina)
 
 ## [2.4.0] - 2018-05-06
 ### Fixed:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@ se_pass: ''
 
 # Sensu package
 sensu_package: sensu
-sensu_pkg_version:  # This 'none' value allows the var to be overriden in /vars or in group/host_vars
 sensu_enterprise_package: sensu-enterprise
 sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -146,8 +146,6 @@ _Note: The above options are intended to provide users with flexibility. This al
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
-| `sensu_pkg_download_url` | `https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/sensu/{{ sensu_package }}.txz` | URL to download Sensu from |
-| `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)
 | Name               | Default Value | Description                  |

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -62,6 +62,8 @@ _Note: The above options are intended to provide users with flexibility. This al
 | `sensu_deploy_rabbitmq_config` | `true`    | Determines whether or not to deploy RabbitMQ config for sensu |
 | `sensu_deploy_redis_config`    | `true`    | Determines whether or not to deploy redis config for sensu |
 | `sensu_deploy_transport_config`    | `true`    | Determines whether or not to deploy transport config for sensu |
+| `sensu_package` | `sensu` | The package to install for Sensu. If you would like to pin versions, for example, append `-1.3.3` to pin the package to version 1.3.3 |
+| `sensu_pkg_state` | `present` | The state to ensure Sensu's package at. Change to `latest` and set `sensu_package` to `sensu` to always ensure the latest Sensu version is installed|
 
 ### Sensu/RabbitMQ SSL certificate properties
 | Name               | Default Value | Description                  |
@@ -102,7 +104,6 @@ _Note: The above options are intended to provide users with flexibility. This al
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `sensu_package`      | sensu       | The name of the Sensu package. |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -116,7 +117,6 @@ _Note: The above options are intended to provide users with flexibility. This al
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `sensu_package`      | sensu       | The name of the Sensu package. |
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)

--- a/docs/role_variables.md
+++ b/docs/role_variables.md
@@ -102,7 +102,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `sensu_package`      | sensu       | The name of the Sensu package. Can optionally include a version (sensu=0.20.3-1) |
+| `sensu_package`      | sensu       | The name of the Sensu package. |
 
 ## Debian
 ### [redis Server Properties](https://sensuapp.org/docs/latest/reference/redis)
@@ -116,7 +116,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 |--------------------|---------------|------------------------------|
 | `sensu_user_name`    | root        | The name of the Sensu service user |
 | `sensu_group_name`   | root        | The name of the Sensu service user's primary group |
-| `sensu_package`      | sensu       | The name of the Sensu package. Can optionally include a version (sensu=0.20.3-1) |
+| `sensu_package`      | sensu       | The name of the Sensu package. |
 
 ## CentOS
 ### [Sensu Properties](https://sensuapp.org/docs/latest/installation/overview)
@@ -146,8 +146,7 @@ _Note: The above options are intended to provide users with flexibility. This al
 | Name               | Default Value | Description                  |
 |--------------------|---------------|------------------------------|
 | `sensu_config_path` | `/usr/local/etc/sensu` | Path to the Sensu configuration directory |
-| `sensu_pkg_version` | `0.29.0_1` | Version of Sensu to download and install |
-| `sensu_pkg_download_url` | `https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/sensu/sensu-{{ sensu_pkg_version }}.txz` | URL to download Sensu from |
+| `sensu_pkg_download_url` | `https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/sensu/{{ sensu_package }}.txz` | URL to download Sensu from |
 | `sensu_pkg_download_path` | `/root/sensu_latest.txz` | Path to store package file to |
 
 ### [RabbitMQ Server Properties](https://sensuapp.org/docs/latest/reference/rabbitmq)

--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -19,4 +19,6 @@
       enabled: yes
 
   - name: Ensure Sensu is installed
-    yum: name={{ sensu_package }} state={{ sensu_pkg_state }}
+    yum:
+      name: {{ sensu_package }}
+      state: {{ sensu_pkg_state }}

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -54,11 +54,11 @@
 
   - name: Ensure Sensu is installed
     package:
-      name: "{{sensu_package }}"
+      name: "{{ sensu_package }}"
       state: "{{ sensu_pkg_state }}"
 
   - name: Ensure Sensu Enterprise is installed
     package:
-      name: {{ sensu_enterprise_package }}
-      state: {{ sensu_pkg_state }}
+      name: "{{ sensu_enterprise_package }}"
+      state: "{{ sensu_pkg_state }}"
     when: se_enterprise

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -4,11 +4,6 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
-  - name: Set sensu_pkg_version {{ ansible_distribution }} override
-    set_fact:
-      sensu_pkg_version: "{{ _sensu_pkg_version }}"
-    when: sensu_pkg_version is none
-
   - name: Ensure the Sensu Core Yum repo is present
     yum_repository:
       name: sensu
@@ -59,7 +54,7 @@
 
   - name: Ensure Sensu is installed
     package:
-      name: "{{sensu_package }}-{{sensu_pkg_version}}"
+      name: "{{sensu_package }}"
       state: "{{ sensu_pkg_state }}"
 
   - name: Ensure Sensu Enterprise is installed

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -59,6 +59,6 @@
 
   - name: Ensure Sensu Enterprise is installed
     package:
-      name={{ sensu_enterprise_package }}
-      state={{ sensu_pkg_state }}
+      name: {{ sensu_enterprise_package }}
+      state: {{ sensu_pkg_state }}
     when: se_enterprise

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -5,7 +5,9 @@
   - include_vars: "{{ ansible_distribution }}.yml"
 
   - name: Ensure the Sensu group is present
-    group: name={{ sensu_group_name }} state=present
+    group:
+      name: {{ sensu_group_name }}
+      state: present
 
   - name: Ensure the Sensu user is present
     user:
@@ -16,19 +18,19 @@
       createhome: true
       state: present
 
-  - name: Create pkgng custom repo config directory
+  - name: Ensure pkgng custom repo config directory exists
     file:
       path: /usr/local/etc/pkg/repos/
       state: directory
 
-  - name: Install sensu repo
+  - name: Ensure Sensu repo is configured
     template:
       src: sensu-freebsd-repo.conf.j2
       dest: /usr/local/etc/pkg/repos/sensu.conf
     notify:
       - Update pkgng database
 
-  - name: Install prerequisite packages
+  - name: Ensure prerequisite packages are installed
     pkgng:
       name: "{{ item }}"
       state: present
@@ -36,7 +38,7 @@
       - bash
       - ca_root_nss
 
-  - name: Install sensu
+  - name: Ensure Sensu is installed
     pkgng:
       name: "{{ sensu_package }}"
-      state: present
+      state: "{{ sensu_pkg_state }}"

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -4,11 +4,6 @@
 
   - include_vars: "{{ ansible_distribution }}.yml"
 
-  - name: Set sensu_pkg_version {{ ansible_distribution }} override
-    set_fact:
-      sensu_pkg_version: "{{ _sensu_pkg_version }}"
-    when: sensu_pkg_version is none
-
   - name: Ensure the Sensu group is present
     group: name={{ sensu_group_name }} state=present
 
@@ -43,5 +38,5 @@
 
   - name: Install sensu
     pkgng:
-      name: "sensu{% if sensu_pkg_version %}-{{ sensu_pkg_version }}{% endif %}"
+      name: "{{ sensu_package }}"
       state: present

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -2,8 +2,5 @@
 # vars/CentOS.yml: Variables for CentOS
 # Defaults are defined in defaults/main.yml
 
-# Sensu/Uchiwa user/group/service properties
-_sensu_pkg_version: '0.29.0'
-
 #Set this to false to disable the EPEL repo installation
 enable_epel_repo: true

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -2,8 +2,5 @@
 # vars/Fedora.yml: Variables for Fedora
 # Defaults are defined in defaults/main.yml
 
-# Sensu/Uchiwa user/group/service properties
-_sensu_pkg_version: '1.2.1'
-
 #RH/Centos 7 version works for Fedora 25 as a client
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,7 +4,6 @@
 
 # Sensu config/package properties
 sensu_config_path: /usr/local/etc/sensu
-sensu_package: sensu-latest
 
 # RabbitMQ options
 rabbitmq_config_path: /usr/local/etc/rabbitmq

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,6 +4,7 @@
 
 # Sensu config/package properties
 sensu_config_path: /usr/local/etc/sensu
+sensu_package: sensu-latest
 
 # RabbitMQ options
 rabbitmq_config_path: /usr/local/etc/rabbitmq

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,7 +4,6 @@
 
 # Sensu config/package properties
 sensu_config_path: /usr/local/etc/sensu
-_sensu_pkg_version: ~
 
 # RabbitMQ options
 rabbitmq_config_path: /usr/local/etc/rabbitmq


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-ansible/issues/154

Currently, we have a variety of ways for folks to pin the package version of Sensu, the package state. This PR switches everyone to one common workflow. Simply setup `sensu_package` to be `sensu-1.3.3` (for example) to pin the Ansible installed sensu version to the 1.3.3 release. Alternatively, for those who want to ensure they always get the latest stable release, leave the default for `sensu_package` and change `sensu_pkg_state` to `latest`. 

This PR deprecates the unique use of `sensu_pkg_version` going forward (which was only used on a subset of supported OS'es). However, I've formatted this change as a none breaking one, by default, this role will not upgrade/downgrade `sensu` unless you've changed `sensu_pkg_state` to `latest`. For folks that have set `sensu_pkg_version`, Sensu will stay as is going forward. However, if you want to guarantee version pinning, please switch `sensu_package` to the specific version. 