### PR TITLE
Feature/fixup sensu role galaxy namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Ansible role is officially mirrored to the `sensu.sensu` namespace (@jaredledvina)
 
 ## [2.4.0] - 2018-05-06
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-cmacrae.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/cmacrae/sensu/) [![Build Status](https://travis-ci.org/sensu/sensu-ansible.svg?branch=master)](https://travis-ci.org/sensu/sensu-ansible)
+# Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-sensu.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/sensu/sensu/) [![Build Status](https://travis-ci.org/sensu/sensu-ansible.svg?branch=master)](https://travis-ci.org/sensu/sensu-ansible)
 
 [![Join the chat at https://slack.sensu.io/](https://slack.sensu.io/badge.svg)](https://slack.sensu.io/)
 
@@ -51,14 +51,14 @@ See [Role Variables](http://ansible-sensu.readthedocs.io/en/latest/role_variable
 ``` yaml
   - hosts: all
     roles:
-      - role: cmacrae.sensu
+      - role: sensu.sensu
 ```
 Or, passing parameter values:
 
 ``` yaml
   - hosts: sensu_masters
     roles:
-      - { role: cmacrae.sensu, sensu_master: true, sensu_include_dashboard: true  }
+      - { role: sensu.sensu, sensu_master: true, sensu_include_dashboard: true  }
 ```
 
 ## Ansible version support

--- a/docs/afewwords.md
+++ b/docs/afewwords.md
@@ -1,7 +1,7 @@
 # A few words from the author
 Well, thanks for bothering to even visit this page!
 
-This role was born out of my own passion for the absolutely excellent projects that it uses.  
+This role was born out of my own passion for the absolutely excellent projects that it uses.
 I figure I have to list them, in no particular order, here they are. __Make sure to check them all out!__
 
 - [Ansible](http://ansible.com/home)
@@ -22,11 +22,11 @@ Coming in the near future:
 I'd be happy to add any others to the list if high demand shows.
 
 ## About updates
-This is a personal project of mine that I work on in my own free time.  
-Most of the real "meat" is there, I just need to restructure and implement conditional includes based on facts.  
+This is a personal project of mine that I work on in my own free time.
+Most of the real "meat" is there, I just need to restructure and implement conditional includes based on facts.
 
-That said, I'm a busy man! So please, [bear with me](http://i.imgur.com/bGhY7oX.jpg). I'll happily accept any contributions, both in [additions to the code](https://github.com/cmacrae/ansible-sensu/pulls), and any [bug reports](https://github.com/cmacrae/ansible-sensu/issues) :)  
+That said, I'm a busy man! So please, [bear with me](http://i.imgur.com/bGhY7oX.jpg). I'll happily accept any contributions, both in [additions to the code](https://github.com/sensu/sensu-ansible/pulls), and any [bug reports](https://github.com/sensu/sensu-ansible/issues) :)
 
 ## If you like it
-Share it! Get it out there; link it all over the place!  
+Share it! Get it out there; link it all over the place!
 It's not just about awesome deployment, it's about exposing people to excellent open source software!

--- a/docs/example_infra.md
+++ b/docs/example_infra.md
@@ -1,6 +1,6 @@
 # Example Infrastructure Layout
 
-This document showcases an example layout for use with the Sensu role within your infrastructure.  
+This document showcases an example layout for use with the Sensu role within your infrastructure.
 It ties in with use of inventory grouping and variables.
 
 ## Inventory & Variables
@@ -46,7 +46,7 @@ Here we have some nodes grouped into `rabbitmq_servers`, `redis_servers`, `sensu
 
 Since we only want one Sensu "master", the default to act as a master in this role is set to `false` - defined by `sensu_master`.
 
-There are several ways to approach setting `sensu_master` to `true` for the node you'd like to act as the Sensu "master".  
+There are several ways to approach setting `sensu_master` to `true` for the node you'd like to act as the Sensu "master".
 Personally, I do this by setting the following in `group_vars/sensu_masters.yml`:
 ``` yaml
 sensu_master: true
@@ -63,7 +63,7 @@ The above code could also be set straight in the node's `host_vars` file: `host_
 	  sensu_include_dashboard: true
 
     roles:
-	  - cmacrae.sensu
+	  - sensu.sensu
 ```
 
 ### RabbitMQ/redis variables

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
-# Ansible Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-cmacrae.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/cmacrae/sensu/)
+# Ansible Sensu [![Ansible Galaxy](https://img.shields.io/badge/galaxy-sensu.sensu-660198.svg?style=flat)](https://galaxy.ansible.com/sensu/sensu/)
 An [Ansible](https://ansible.com) role that deploys a full [Sensu](https://sensuapp.org) stack, a modern, open source monitoring framework.
-
-[![Join the chat at https://gitter.im/cmacrae/ansible-sensu](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cmacrae/ansible-sensu?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Features
 - Deploy a full [Sensu](https://sensuapp.org) stack, including RabbitMQ, redis, and the [Uchiwa dashboard](https://uchiwa.io/#/)
@@ -12,7 +10,7 @@ An [Ansible](https://ansible.com) role that deploys a full [Sensu](https://sensu
 - Highly configurable
 
 ## Batteries included, but not imposed
-Along with deploying the Sensu Server, API and clients, this role can deploy a full stack: [RabbitMQ](http://www.rabbitmq.com/), [redis](http://redis.io), and the [Uchiwa dashboard](https://uchiwa.io/#/).  
+Along with deploying the Sensu Server, API and clients, this role can deploy a full stack: [RabbitMQ](http://www.rabbitmq.com/), [redis](http://redis.io), and the [Uchiwa dashboard](https://uchiwa.io/#/).
 However, if you want to rely on other roles/management methods to deploy/manage these services, [it's nice and easy to integrate this role](integration/).
 
 ## Requirements
@@ -33,26 +31,26 @@ This role requires Ansible 2.0
 - NetBSD
 
 ## Role Variables
-All variables have sensible defaults, which can be found in `defaults/main.yml`.  
+All variables have sensible defaults, which can be found in `defaults/main.yml`.
 Head over to [the role variables page](role_variables.md) to review them
 
 ## Install (Ansible Galaxy)
-To install this role from [Ansible Galaxy](https://galaxy.ansible.com), simpy run:  
-`ansible-galaxy install cmacrae.sensu`
+To install this role from [Ansible Galaxy](https://galaxy.ansible.com), simpy run:
+`ansible-galaxy install sensu.sensu`
 
 ## Example Playbook
 
 ``` yaml
   - hosts: all
     roles:
-      - role: cmacrae.sensu
+      - role: sensu.sensu
 ```
 Or, passing parameter values:
 
 ``` yaml
   - hosts: sensu_masters
     roles:
-	  - { role: cmacrae.sensu, sensu_master: true, sensu_include_dashboard: true  }
+	  - { role: sensu.sensu, sensu_master: true, sensu_include_dashboard: true  }
 ```
 
 License
@@ -61,12 +59,12 @@ License
 
 Author Information
 ------------------
-Created by [Calum MacRae](http://cmacr.ae)
+Originally created by [Calum MacRae](http://cmacr.ae)
+Supported by the [Sensu Community Ansible Maintainers](https://github.com/sensu-plugins/community/#maintained-areas)
 
 ### Contributors
-Stephen Muth - ([@smuth4](https://github.com/smuth4))
+See the projects [Contributors page](https://github.com/sensu/sensu-ansible/graphs/contributors)
 
-Feel free to:  
-Contact me - [@calumacrae](https://twitter.com/calumacrae), [mailto:calum0macrae@gmail.com](calum0macrae@gmail.com)  
-[Raise an issue](https://github.com/cmacrae/ansible-sensu/issues)  
-[Contribute](https://github.com/cmacrae/ansible-sensu/pulls)  
+Feel free to:
+[Raise an issue](https://github.com/sensu/sensu-ansible/issues)
+[Contribute](https://github.com/sensu/sensu-ansible/pulls)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Ansible Sensu
-site_url: https://galaxy.ansible.com/cmacrae/sensu/
-repo_url: https://github.com/cmacrae/ansible-sensu/
+site_url: https://galaxy.ansible.com/sensu/sensu
+repo_url: https://github.com/sensu/sensu-ansible
 site_description: An Ansible role to deploy a fully dynamic Sensu stack!
 site_author: Calum MacRae
 

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks/SmartOS/main.yml: "Set-up" playbook for sensu.sensu-ansible role
+# tasks/SmartOS/main.yml: "Set-up" playbook for sensu.sensu role
 # This takes care of base prerequisites for Joyent SmartOS
 
   - include_vars: "{{ ansible_distribution }}.yml"

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks/SmartOS/main.yml: "Set-up" playbook for cmacrae.sensu role
+# tasks/SmartOS/main.yml: "Set-up" playbook for sensu.sensu-ansible role
 # This takes care of base prerequisites for Joyent SmartOS
 
   - include_vars: "{{ ansible_distribution }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks/main.yml: "Master" playbook for the cmacrae.sensu role
+# tasks/main.yml: "Master" playbook for the sensu.sensu-ansible role
 
   - include_vars: "{{ ansible_distribution }}.yml"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks/main.yml: "Master" playbook for the sensu.sensu-ansible role
+# tasks/main.yml: "Master" playbook for the sensu.sensu role
 
   - include_vars: "{{ ansible_distribution }}.yml"
 

--- a/tests/provision.yml
+++ b/tests/provision.yml
@@ -10,4 +10,4 @@
 
 
   roles:
-    - ../../cmacrae.sensu
+    - ../../sensu.sensu


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-ansible/issues/152 

Soooooo, Ansible galaxy kinda went a bit over the top and when I ran an `ansible-galaxy import sensu sensu-ansible --role-name=sensu`, it appears to have MOVED https://galaxy.ansible.com/cmacrae/sensu/ to https://galaxy.ansible.com/sensu/sensu/. 

This PR updates all of the documentation to cleanly move everything to the Sensu namespace while leaving credit to Calum for all of the real work here. 