### PR TITLE
Update README w/ explicit Ansible version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Or, passing parameter values:
 ```
 
 ## Ansible version support
-All changes to this role are actively tested with the last two stable versions of Ansible to ensure compatibility. As such, this role
-only officially supports running with the last two stable releases of Ansible, which aligns with the [Ansible support model](http://docs.ansible.com/ansible/latest/release_and_maintenance.html#release-status).
+All changes to this role are actively tested against Ansible 2.3 and 2.4 at this time. Ansible 2.3 is required at a minimum.
 
 
 License


### PR DESCRIPTION
Per the conversation in `#ansible` yesterday, this role has yet to be full tested with Ansible 2.5. While I want to get that completed and released, I don't have a lot of time (feel free to PR that though!). 
For now, let's just be explicit and call out that we've only tested this role with 2.3 and 2.4 at this time. 