### PR TITLE
Feature/enable ansible linting across role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Fixup the CentOS RabbitMQ install w/ full GPG signing verification (@jaredledvina)
 - Various syntax cleanups and testing documentation updates (@jaredledvina)
 - Enable `yamllint` checking and fixup all files to pass checks (@jaredledvina)
+- Enable `ansible-lint` checking and fixup all errors to pass checks (@jaredledvina)
 
 ## [2.4.0] - 2018-05-06
 ### Fixed:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -59,7 +59,7 @@
   command: /usr/sbin/svccfg import /opt/local/lib/svc/manifest/uchiwa.xml
 
 - name: Build and deploy Uchiwa
-  shell: npm install --production
+  command: npm install --production
   args:
     chdir: "{{ uchiwa_path }}/go/src/github.com/sensu/uchiwa"
   become: true

--- a/molecule/amazonlinux/molecule.yml
+++ b/molecule/amazonlinux/molecule.yml
@@ -31,7 +31,7 @@ provisioner:
     verify: ../default/verify.yml
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -31,7 +31,7 @@ provisioner:
     verify: ../default/verify.yml
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
     verify: ../default/verify.yml
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 lint:
   name: yamllint
-  enabled: False
+  enabled: True
 platforms:
   - name: debian-8
     image: dokken/debian-8
@@ -89,7 +89,7 @@ provisioner:
   directory: ../default/
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -40,7 +40,7 @@ provisioner:
     verify: ../default/verify.yml
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -39,7 +39,7 @@ provisioner:
     verify: ../default/verify.yml
   lint:
     name: ansible-lint
-    enabled: False
+    enabled: True
   inventory:
     group_vars:
       all:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/main.yml: "Master" playbook for the sensu.sensu role
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include distribution specific variables
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - include: "{{ role_path }}/tasks/{{ ansible_distribution }}/main.yml"
   tags: setup


### PR DESCRIPTION
This PR globally enables `ansible-lint`'ing across the role and fixes up only two critical errors in the role. 