### PR TITLE
Tests - Ensure Sensu is healthly

### DIFF
--- a/molecule/default/tests/test_default.rb
+++ b/molecule/default/tests/test_default.rb
@@ -43,3 +43,10 @@ describe port(3000) do
   its('protocols') { should include 'tcp' }
   its('addresses') { should be_in ['0.0.0.0', '::'] }
 end
+
+# Ensure Sensu API has one consumer
+describe http('http://127.0.0.1:4567/health',
+              auth: { user: 'admin', pass: 'secret' },
+              params: { consumers: 1 }) do
+  its('status') { should eq 204 }
+end


### PR DESCRIPTION
This adds a basic test that uses the Sensu `/health` API w/ the `consumers` param to validate that all changes to this role result in the Sensu API returning that it's healthy with 1 consumer. This is the default setup for this role so, assuming the tests really do work, this will pass for everyone. 