### PR TITLE
[Cleanup] Dont publish testing/dev files to Ansible Galaxy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+Pipfile export-ignore
+Pipfile.lock export-ignore
+docs/ export-ignore
+mkdocs.yml export-ignore
+molecule/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 Pipfile export-ignore
 Pipfile.lock export-ignore
+.travis.yml export-ignore
 docs/ export-ignore
 mkdocs.yml export-ignore
 molecule/ export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
+- Stop publishing development/testing files to Ansible Galaxy (@jaredledvina)
 
 ## [2.5.0] - 2018-06-16
 ### Changed


### PR DESCRIPTION
I noticed that the installed role from `ansible-galaxy install` ends up with a ton of cruft (testing bits, docs, etc). 

This uses a trick from https://github.com/srizzling/rkt-role/blob/master/.gitattributes which I found over on https://github.com/ansible/galaxy/issues/78 to have Ansible Galaxy not publish the role with the configured files/directories. See https://git-scm.com/docs/gitattributes#_creating_an_archive as well. 