### PR TITLE
Support configuring Tessen on the Sensu Servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
+- Add support for configuring [Tessen](https://docs.sensu.io/sensu-core/1.4/reference/tessen/) via `sensu_enable_tessen` (@jaredledvina)
 
 ## [2.5.0] - 2018-06-16
 ### Changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,6 +87,7 @@ sensu_client_safe_mode: false
 sensu_deploy_rabbitmq_config: true
 sensu_deploy_redis_config: true
 sensu_deploy_transport_config: true
+sensu_enable_tessen: false
 
 # Sensu/RabbitMQ SSL certificate properties
 sensu_ssl_gen_certs: true

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -11,13 +11,27 @@
     src: sensu-api.json.j2
   notify: restart sensu-api service
 
+- name: Deploy Tessen server configuratiuon
+  template:
+    dest: "{{ sensu_config_path }}/conf.d/tessen.json"
+    owner: "{{ sensu_user_name }}"
+    group: "{{ sensu_group_name }}"
+    src: sensu-tessen.json.j2
+  notify: restart sensu-server service
+
 - include: "{{ role_path }}/tasks/SmartOS/server.yml"
   when: ansible_distribution == "SmartOS"
   static: false
 
 - name: Ensure Sensu server service is running
-  service: name={{ sensu_server_service_name if not se_enterprise else sensu_enterprise_service_name }} state=started enabled=yes
+  service:
+    name: "{{ sensu_server_service_name if not se_enterprise else sensu_enterprise_service_name }}"
+    state: started
+  enabled: yes
 
 - name: Ensure Sensu API service is running
-  service: name=sensu-api state=started enabled=yes
+  service:
+    name: sensu-api
+    state: started
+    enabled: yes
   when: not se_enterprise

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -27,7 +27,7 @@
   service:
     name: "{{ sensu_server_service_name if not se_enterprise else sensu_enterprise_service_name }}"
     state: started
-  enabled: yes
+    enabled: yes
 
 - name: Ensure Sensu API service is running
   service:

--- a/templates/sensu-tessen.json.j2
+++ b/templates/sensu-tessen.json.j2
@@ -1,0 +1,5 @@
+{
+  "tessen": {
+    "enabled": {{ sensu_enable_tessen | bool | lower }}
+  }
+}


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-ansible/issues/153, defaults to `false` as does upstream, allows folks to configure it to `true` if they want to submit data back up to Sensu. 
Upstream docs on the feature can be found here: https://docs.sensu.io/sensu-core/1.4/reference/tessen/

