### PR TITLE
Switch test from filter to conditional

### DIFF
--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -39,7 +39,7 @@
 
 - name: Wait for RabbitMQ to be up and running before asking to create a vhost
   pause: seconds=3
-  when: rabbitmq_state|changed
+  when: rabbitmq_state is changed
 
 - block:
     - name: Ensure Sensu RabbitMQ vhost exists


### PR DESCRIPTION
```
    TASK [sensu-ansible : Wait for RabbitMQ to be up and running before asking to create a vhost] ***
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|changed` instead use `result is changed`. This feature will be removed
in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

Just one of a few warnings that need to be solved for https://github.com/sensu/sensu-ansible/issues/156

