### PR TITLE
Feature/ansible tweaks speed up tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site
 molecule/default/data/
+molecule/*/cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Add support for configuring [Tessen](https://docs.sensu.io/sensu-core/1.4/reference/tessen/) via `sensu_enable_tessen` (@jaredledvina)
 - Stop publishing development/testing files to Ansible Galaxy (@jaredledvina)
+- Update molecule's testing configuration for speed and task profiling (@jaredledvina)
 
 ## [2.5.0] - 2018-06-16
 ### Changed

--- a/molecule/amazonlinux/molecule.yml
+++ b/molecule/amazonlinux/molecule.yml
@@ -23,6 +23,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   playbooks:
     prepare: ../default/prepare.yml
     create: ../default/create.yml

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -23,6 +23,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   playbooks:
     prepare: ../default/prepare.yml
     create: ../default/create.yml

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -26,7 +26,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_whitelist: timer,profile_tasks 
+      callback_whitelist: timer,profile_tasks
       fact_caching: jsonfile
       fact_caching_connection: ./cache
       poll_interval: 3

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -24,6 +24,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks 
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   playbooks:
     prepare: ../default/prepare.yml
     create: ../default/create.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -86,6 +86,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   directory: ../default/
   lint:
     name: ansible-lint

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -32,6 +32,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   playbooks:
     prepare: ../default/prepare.yml
     create: ../default/create.yml

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -31,6 +31,15 @@ platforms:
 #      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: timer,profile_tasks
+      fact_caching: jsonfile
+      fact_caching_connection: ./cache
+      poll_interval: 3
+      forks: 100
+    connection:
+      pipelining: true
   playbooks:
     prepare: ../default/prepare.yml
     create: ../default/create.yml


### PR DESCRIPTION
This PR should help cut down some time for the TravisCI tests to complete but enabling fact caching, connection pipelining, lowering the polling interval from 15 seconds to 3, and bumping the max number of forks to 100. 

It also configured the `timer` and `profile_tasks` plugins so we can further figure out where the most time is spent during the role deployment. 