### PR TITLE
TravisCI - Cache Pip and Pipenv bits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ addons:
   apt:
     packages:
       - docker-ce
+cache:
+  pip: true
+  directories:
+    - ~/.cache/pipenv
 install:
   - pip install pipenv
   - pipenv install --two --dev


### PR DESCRIPTION
I'm still working on tweaking the TravisCI builds to be as quick as possible. This PR updates the configuration to have TravisCI cache both `pip` and the `pipenv` directory as currently, `pipenv` is not a built in on the TravisCI but, `pip` is. 
Taking a quick look across builds, the `pipenv install` step takes around 80seconds on each build. 