### PR TITLE
Feature/erlang breaks the world

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
   - SCENARIO=centos
   - SCENARIO=fedora
   - SCENARIO=amazonlinux
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: SCENARIO=amazonlinux  # https://github.com/inspec/train/pull/312
 services: docker
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Stop publishing development/testing files to Ansible Galaxy (@jaredledvina)
 - Update molecule's testing configuration for speed and task profiling (@jaredledvina)
 - Update Inspec to latest stable & refactor shared testing files (@jaredledvina)
+- RabbitMQ - Expose a varient distro repo configs via variables for more flexibility
+- RabbitMQ - Configure apt-preferences and pin erlang to version 20.X
+- Fedora - RabbitMQ - Reconfigure GPG key pinning to match CentOS/AmazonLinux
+- Fedora/CentOS/AmazonLinux - Upgrade to zero-dep erlang v20 repo's
 
 ## [2.5.0] - 2018-06-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Stop publishing development/testing files to Ansible Galaxy (@jaredledvina)
 - Update molecule's testing configuration for speed and task profiling (@jaredledvina)
 - Update Inspec to latest stable & refactor shared testing files (@jaredledvina)
-- RabbitMQ - Expose a varient distro repo configs via variables for more flexibility
-- RabbitMQ - Configure apt-preferences and pin erlang to version 20.X
-- Fedora - RabbitMQ - Reconfigure GPG key pinning to match CentOS/AmazonLinux
-- Fedora/CentOS/AmazonLinux - Upgrade to zero-dep erlang v20 repo's
+- RabbitMQ - Expose a varient distro repo configs via variables for more flexibility (@jaredledvina)
+- RabbitMQ - Configure apt-preferences and pin erlang to version 20.3.X (@jaredledvina)
+- Fedora - RabbitMQ - Reconfigure GPG key pinning to match CentOS/AmazonLinux (@jaredledvina)
+- Fedora/CentOS/AmazonLinux - Upgrade to zero-dep erlang v20 repo's (@jaredledvina)
 
 ## [2.5.0] - 2018-06-16
 ### Changed

--- a/molecule/amazonlinux/molecule.yml
+++ b/molecule/amazonlinux/molecule.yml
@@ -53,11 +53,11 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       amazonlinux-1:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/6/inspec-2.2.16-1.el6.x86_64.rpm
-        inspec_download_sha256sum: 616af0700b3c80f545d143dfe24c987039a8d715cbb615aac5ad94b0e0b34323
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/6/inspec-2.2.27-1.el6.x86_64.rpm
+        inspec_download_sha256sum: 1125739aaaf78bdf391f1520de5830576978af6a0feba4a9eefefa804da88796
       amazonlinux-2:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/7/inspec-2.2.16-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 2fdf2000630c38828c3172d471a61ecc4b8ff58ce9bee9a5543a99434be30e83
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
+        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -53,11 +53,11 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       centos-6:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/6/inspec-2.2.16-1.el6.x86_64.rpm
-        inspec_download_sha256sum: 616af0700b3c80f545d143dfe24c987039a8d715cbb615aac5ad94b0e0b34323
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/6/inspec-2.2.27-1.el6.x86_64.rpm
+        inspec_download_sha256sum: 1125739aaaf78bdf391f1520de5830576978af6a0feba4a9eefefa804da88796
       centos-7:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/7/inspec-2.2.16-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 2fdf2000630c38828c3172d471a61ecc4b8ff58ce9bee9a5543a99434be30e83
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
+        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -54,11 +54,11 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       debian-8:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/ubuntu/16.04/inspec_2.2.16-1_amd64.deb
-        inspec_download_sha256sum: c65a9ee4a38dac46760caf2500b4504ba49845423420be685aa8ea20ea52f3b4
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
+        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
       debian-9:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/ubuntu/16.04/inspec_2.2.16-1_amd64.deb
-        inspec_download_sha256sum: c65a9ee4a38dac46760caf2500b4504ba49845423420be685aa8ea20ea52f3b4
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
+        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
 verifier:
   name: inspec
   directory: ../shared/

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -62,14 +62,14 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       fedora-26:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/7/inspec-2.2.16-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 2fdf2000630c38828c3172d471a61ecc4b8ff58ce9bee9a5543a99434be30e83
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
+        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
       fedora-27:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/7/inspec-2.2.16-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 2fdf2000630c38828c3172d471a61ecc4b8ff58ce9bee9a5543a99434be30e83
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
+        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
       fedora-28:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/el/7/inspec-2.2.16-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 2fdf2000630c38828c3172d471a61ecc4b8ff58ce9bee9a5543a99434be30e83
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
+        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -61,14 +61,14 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       ubuntu-14.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/ubuntu/14.04/inspec_2.2.16-1_amd64.deb
-        inspec_download_sha256sum: c65a9ee4a38dac46760caf2500b4504ba49845423420be685aa8ea20ea52f3b4
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/14.04/inspec_2.2.27-1_amd64.deb
+        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
       ubuntu-16.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/ubuntu/16.04/inspec_2.2.16-1_amd64.deb
-        inspec_download_sha256sum: c65a9ee4a38dac46760caf2500b4504ba49845423420be685aa8ea20ea52f3b4
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
+        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
       ubuntu-18.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.16/ubuntu/18.04/inspec_2.2.16-1_amd64.deb
-        inspec_download_sha256sum: c65a9ee4a38dac46760caf2500b4504ba49845423420be685aa8ea20ea52f3b4
+        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/18.04/inspec_2.2.27-1_amd64.deb
+        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/tasks/Amazon/rabbit.yml
+++ b/tasks/Amazon/rabbit.yml
@@ -6,29 +6,26 @@
 
 - name: Configure RabbitMQ/RabbitMQ-erlang GPG keys in the RPM keyring
   rpm_key:
-    key: "{{ item }}"
+    key: "{{ sensu_rabbitmq_signing_key }}"
     state: present
-  with_items:
-    - https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-    - https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
   register: sensu_rabbitmq_import_key
 
 - name: Add RabbitMQ's repo
   yum_repository:
     name: rabbitmq
     description: rabbitmq
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/{{ epel_version }}"
+    baseurl: "{{ sensu_rabbitmq_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_signing_key }}"
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/{{ epel_version }}"
+    baseurl: "{{ sensu_rabbitmq_erlang_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_erlang_signing_key }}"
     repo_gpgcheck: no
 
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869

--- a/tasks/CentOS/rabbit.yml
+++ b/tasks/CentOS/rabbit.yml
@@ -4,31 +4,28 @@
 
 - include_vars: "{{ ansible_distribution }}.yml"
 
-- name: Configure RabbitMQ/RabbitMQ-erlang GPG keys in the RPM keyring
+- name: Configure RabbitMQ GPG keys in the RPM keyring
   rpm_key:
-    key: "{{ item }}"
+    key: "{{ sensu_rabbitmq_signing_key }}"
     state: present
-  with_items:
-    - https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-    - https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
   register: sensu_rabbitmq_import_key
 
 - name: Add RabbitMQ's repo
   yum_repository:
     name: rabbitmq
     description: rabbitmq
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/{{ansible_distribution_major_version}}"
+    baseurl: "{{ sensu_rabbitmq_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_signing_key }}"
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/{{ansible_distribution_major_version}}"
+    baseurl: "{{ sensu_rabbitmq_erlang_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_erlang_signing_key }}"
     repo_gpgcheck: no
 
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -16,6 +16,14 @@
     state: present
     update_cache: true
 
+- name: Ensure Erlang APT preferences is configured
+  template:
+    src: erlang-apt-preferences.j2
+    dest: /etc/apt/preferences.d/erlang
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Ensure the Erlang APT repo GPG key is present
   apt_key:
     url: "{{ sensu_rabbitmq_erlang_signing_key }}"

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -6,24 +6,24 @@
 
 - name: Ensure the RabbitMQ APT repo GPG key is present
   apt_key:
-    url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    url: "{{ sensu_rabbitmq_signing_key }}"
     state: present
 
 - name: Ensure the RabbitMQ APT repo is present
   apt_repository:
-    repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+    repo: "{{ sensu_rabbitmq_repo }}"
     filename: rabbitmq
     state: present
     update_cache: true
 
 - name: Ensure the Erlang APT repo GPG key is present
   apt_key:
-    url: https://packages.erlang-solutions.com/debian/erlang_solutions.asc
+    url: "{{ sensu_rabbitmq_erlang_signing_key }}"
     state: present
 
 - name: Ensure the Erlang APT repo is present
   apt_repository:
-    repo: "deb https://packages.erlang-solutions.com/debian {{ ansible_distribution_release }} contrib"
+    repo: "{{ sensu_rabbitmq_erlang_repo }}"
     filename: erlang
     state: present
     update_cache: true

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -4,23 +4,48 @@
 
 - include_vars: "{{ ansible_distribution }}.yml"
 
+- name: Configure RabbitMQ GPG keys in the RPM keyring
+  rpm_key:
+    key: "{{ sensu_rabbitmq_signing_key }}"
+    state: present
+  register: sensu_rabbitmq_import_key
+
 - name: Add RabbitMQ's repo
   yum_repository:
     name: rabbitmq
     description: rabbitmq
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/7"
+    baseurl: "{{ sensu_rabbitmq_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_signing_key }}"
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
-    baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/19/el/7"
+    baseurl: "{{ sensu_rabbitmq_erlang_baseurl }}"
     gpgcheck: yes
-    gpgkey: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    gpgkey: "{{ sensu_rabbitmq_erlang_signing_key }}"
     repo_gpgcheck: no
+
+# HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
+# Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
+- name: Make yum cache to import GPG keys
+  command: "yum -q makecache -y --disablerepo='*' --enablerepo='{{ item }}'"
+  args:
+    warn: false
+  when: sensu_rabbitmq_import_key.changed
+  with_items:
+    - rabbitmq
+    - rabbitmq-erlang
+
+# Hard dependency for rabbitmq-server, however, typically comes from EPEL, so
+# we simply install it here, as we purposely disable epel when installing rabbitmq
+# causing dependency issues during installs
+- name: Ensure socat is installed
+  dnf:
+    name: socat
+    state: present
 
 - name: Ensure Erlang & RabbitMQ are installed
   dnf:
@@ -29,3 +54,4 @@
       - rabbitmq-server
     state: present
     enablerepo: rabbitmq,rabbitmq-erlang
+    disablerepo: epel

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -4,6 +4,11 @@
 
 - include_vars: "{{ ansible_distribution }}.yml"
 
+- name: Ensure jemalloc is installed as a dependency of Redis
+  dnf:
+    name: jemalloc
+    state: present
+
 - name: Ensure redis is installed
   dnf:
     name: "{{ redis_pkg_name }}"

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -16,6 +16,14 @@
     state: present
     update_cache: true
 
+- name: Ensure Erlang APT preferences is configured
+  template:
+    src: erlang-apt-preferences.j2
+    dest: /etc/apt/preferences.d/erlang
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Ensure the Erlang APT repo GPG key is present
   apt_key:
     url: "{{ sensu_rabbitmq_erlang_signing_key }}"

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure the RabbitMQ APT repo GPG key is present
   apt_key:
-    url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    url: "{{ sensu_rabbitmq_signing_key }}"
     state: present
 
 - name: Ensure the RabbitMQ APT repo is present
@@ -18,7 +18,7 @@
 
 - name: Ensure the Erlang APT repo GPG key is present
   apt_key:
-    url: https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+    url: "{{ sensu_rabbitmq_erlang_signing_key }}"
     state: present
 
 - name: Ensure the Erlang APT repo is present

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -6,10 +6,15 @@
 - include: "{{ ansible_distribution }}/rabbit.yml"
 
 - name: Ensure RabbitMQ SSL directory exists
-  file: dest={{ rabbitmq_config_path }}/ssl state=directory
+  file:
+    dest: "{{ rabbitmq_config_path }}/ssl"
+    state: directory
 
 - name: Ensure RabbitMQ SSL certs/keys are in place
-  copy: src="{{ item.src }}" dest="{{ rabbitmq_config_path }}/ssl/{{ item.dest }}" remote_src="{{ sensu_ssl_deploy_remote_src }}"
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ rabbitmq_config_path }}/ssl/{{ item.dest }}"
+    remote_src: "{{ sensu_ssl_deploy_remote_src }}"
   with_items:
     - { src: "{{ sensu_ssl_server_cacert }}", dest: cacert.pem }
     - { src: "{{ sensu_ssl_server_cert }}", dest: cert.pem }
@@ -38,12 +43,15 @@
   register: rabbitmq_state
 
 - name: Wait for RabbitMQ to be up and running before asking to create a vhost
-  pause: seconds=3
+  pause:
+    seconds: 3
   when: rabbitmq_state is changed
 
 - block:
     - name: Ensure Sensu RabbitMQ vhost exists
-      rabbitmq_vhost: name={{ rabbitmq_sensu_vhost }} state=present
+      rabbitmq_vhost:
+        name: "{{ rabbitmq_sensu_vhost }}"
+        state: present
 
     - name: Ensure Sensu RabbitMQ user has access to the Sensu vhost
       rabbitmq_user:

--- a/templates/erlang-apt-preferences.j2
+++ b/templates/erlang-apt-preferences.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+Package: {{ sensu_erlang_pin_package }}
+Pin: version {{ sensu_erlang_pin_version }}
+Pin-Priority: 1000

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -13,7 +13,7 @@ epel_repo_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{epel
 
 # RabbitMQ/Erlang
 sensu_rabbitmq_repo_version: v3.7.x
-sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -10,3 +10,11 @@ sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/{{epel_version}}/$b
 # Set this to false to disable the EPEL repo installation
 enable_epel_repo: true
 epel_repo_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{epel_version}}.noarch.rpm"
+
+# RabbitMQ/Erlang
+sensu_rabbitmq_repo_version: v3.7.x
+sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ epel_version }}"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -6,7 +6,7 @@
 enable_epel_repo: true
 
 sensu_rabbitmq_repo_version: v3.7.x
-sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ ansible_distribution_major_version }}"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -8,6 +8,6 @@ enable_epel_repo: true
 sensu_rabbitmq_repo_version: v3.7.x
 sensu_rabbitmq_erlang_repo_version: 19
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ ansible_distribution_major_version }}"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
-sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ ansible_distribution_major_version }}"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -4,3 +4,10 @@
 
 # Set this to false to disable the EPEL repo installation
 enable_epel_repo: true
+
+sensu_rabbitmq_repo_version: v3.7.x
+sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ epel_version }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,8 @@
 redis_pkg_name: redis-server
 redis_service_name: redis-server
 
+sensu_erlang_pin_package: 'esl-erlang erlang*'
+sensu_erlang_pin_version: '1:20*'
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
 sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,3 +5,8 @@
 # redis server properties
 redis_pkg_name: redis-server
 redis_service_name: redis-server
+
+sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc
+sensu_rabbitmq_erlang_repo: "deb https://packages.erlang-solutions.com/debian {{ ansible_distribution_release }} contrib"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,7 +7,7 @@ redis_pkg_name: redis-server
 redis_service_name: redis-server
 
 sensu_erlang_pin_package: 'esl-erlang erlang*'
-sensu_erlang_pin_version: '1:20*'
+sensu_erlang_pin_version: '1:20.3*'
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
 sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -4,3 +4,9 @@
 
 # RH/Centos 7 version works for Fedora 25 as a client
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"
+sensu_rabbitmq_repo_version: v3.7.x
+sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/7"

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -7,6 +7,6 @@ sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"
 sensu_rabbitmq_repo_version: v3.7.x
 sensu_rabbitmq_erlang_repo_version: 19
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/7"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
 sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/7"

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -5,7 +5,7 @@
 # RH/Centos 7 version works for Fedora 25 as a client
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/7/$basearch/"
 sensu_rabbitmq_repo_version: v3.7.x
-sensu_rabbitmq_erlang_repo_version: 19
+sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/7"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -8,7 +8,7 @@ redis_service_name: redis-server
 
 
 sensu_erlang_pin_package: 'esl-erlang erlang*'
-sensu_erlang_pin_version: '1:20*'
+sensu_erlang_pin_version: '1:20.3*'
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
 sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -6,5 +6,7 @@
 redis_pkg_name: redis-server
 redis_service_name: redis-server
 
+sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc
 sensu_rabbitmq_erlang_repo: "deb https://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -6,6 +6,9 @@
 redis_pkg_name: redis-server
 redis_service_name: redis-server
 
+
+sensu_erlang_pin_package: 'esl-erlang erlang*'
+sensu_erlang_pin_version: '1:20*'
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
 sensu_rabbitmq_erlang_signing_key: https://packages.erlang-solutions.com/debian/erlang_solutions.asc


### PR DESCRIPTION
If this build goes through, this should close out https://github.com/sensu/sensu-ansible/issues/180 

Short version: Erlang 21.X was released and is *not* support yet by RabbitMQ, this re-configures `apt` distro's to use pinning to prevent them from upgrading as they install from Erlang Solutions. This isn't an issue for `yum` distro's as they use the Zero dep RPM's from RabbitMQ directly. This change also updates the `yum` distro's to use Erlang 20.3.X to match `apt` distro's per http://www.rabbitmq.com/which-erlang.html#unsupported%20versions and cleans up a lot of logic across everything. 