### PR TITLE
Feature/bump inspec reenable amazonlinux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
   - SCENARIO=centos
   - SCENARIO=fedora
   - SCENARIO=amazonlinux
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: SCENARIO=amazonlinux  # https://github.com/inspec/train/pull/312
 services: docker
 addons:
   apt:

--- a/molecule/amazonlinux/molecule.yml
+++ b/molecule/amazonlinux/molecule.yml
@@ -53,11 +53,9 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       amazonlinux-1:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/6/inspec-2.2.27-1.el6.x86_64.rpm
-        inspec_download_sha256sum: 1125739aaaf78bdf391f1520de5830576978af6a0feba4a9eefefa804da88796
+        inspec_version: el6
       amazonlinux-2:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
+        inspec_version: el7
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -53,11 +53,9 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       centos-6:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/6/inspec-2.2.27-1.el6.x86_64.rpm
-        inspec_download_sha256sum: 1125739aaaf78bdf391f1520de5830576978af6a0feba4a9eefefa804da88796
+        inspec_version: el6
       centos-7:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
+        inspec_version: el7
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -54,11 +54,9 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       debian-8:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
-        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
+        inspec_version: ubuntu1604
       debian-9:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
-        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
+        inspec_version: ubuntu1604
 verifier:
   name: inspec
   directory: ../shared/

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -62,14 +62,11 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       fedora-26:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
+        inspec_version: el7
       fedora-27:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
+        inspec_version: el7
       fedora-28:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/el/7/inspec-2.2.27-1.el7.x86_64.rpm
-        inspec_download_sha256sum: 9c0c1f3b9e14737d40554e0791658187d91c5eb0640f9514602945c5633399df
+        inspec_version: el7
 verifier:
   name: inspec
   directory: ../shared/tests/

--- a/molecule/shared/verify.yml
+++ b/molecule/shared/verify.yml
@@ -8,9 +8,24 @@
   become: true
   vars:
     inspec_download_source_dir: /usr/local/src
-    inspec_package_name: "{{ inspec_download_url.split('/')[-1] }}"
     inspec_bin: /opt/inspec/bin/inspec
     inspec_test_directory: "/tmp/molecule/inspec"
+    inspec_downloads:
+      el6:
+        url: https://packages.chef.io/files/stable/inspec/2.2.35/el/6/inspec-2.2.35-1.el6.x86_64.rpm
+        sha256: 824d2a4fa801206c2ba10bca2b2a04783f6e6a3690a59e0618b2c7232036b01f
+      el7:
+        url: https://packages.chef.io/files/stable/inspec/2.2.35/el/7/inspec-2.2.35-1.el7.x86_64.rpm
+        sha256: 610c60132ac28f2f54e7d17a9b7afeaec3e11912c1463584495e0e4e81667200
+      ubuntu1404:
+        url: https://packages.chef.io/files/stable/inspec/2.2.35/ubuntu/14.04/inspec_2.2.35-1_amd64.deb
+        sha256: 2cff0ee43eae1dcca8591b947f9175a6771964e8017af99be9adfb5e581a06e0
+      ubuntu1604:
+        url: https://packages.chef.io/files/stable/inspec/2.2.35/ubuntu/16.04/inspec_2.2.35-1_amd64.deb
+        sha256: 2cff0ee43eae1dcca8591b947f9175a6771964e8017af99be9adfb5e581a06e0
+      ubuntu1804:
+        url: https://packages.chef.io/files/stable/inspec/2.2.35/ubuntu/18.04/inspec_2.2.35-1_amd64.deb
+        sha256: 2cff0ee43eae1dcca8591b947f9175a6771964e8017af99be9adfb5e581a06e0
   tasks:
     - name: Install system dependencies for Inspec
       package:
@@ -23,9 +38,9 @@
 
     - name: Download Inspec
       get_url:
-        url: "{{ inspec_download_url }}"
+        url: "{{ inspec_downloads[inspec_version]['url'] }}"
         dest: "{{ inspec_download_source_dir }}"
-        sha256sum: "{{ inspec_download_sha256sum }}"
+        sha256sum: "{{ inspec_downloads[inspec_version]['sha256'] }}"
         mode: 0755
       register: inspec_download
 

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -61,14 +61,11 @@ provisioner:
           address: 127.0.0.1
     host_vars:
       ubuntu-14.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/14.04/inspec_2.2.27-1_amd64.deb
-        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
+        inspec_version: ubuntu1404
       ubuntu-16.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/16.04/inspec_2.2.27-1_amd64.deb
-        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
+        inspec_version: ubuntu1604
       ubuntu-18.04:
-        inspec_download_url: https://packages.chef.io/files/stable/inspec/2.2.27/ubuntu/18.04/inspec_2.2.27-1_amd64.deb
-        inspec_download_sha256sum: ae6c1214643e1dbfa03c2b87432529132bd6e1fcdc20863bd9ee038cbfb705a0
+        inspec_version: ubuntu1804
 verifier:
   name: inspec
   directory: ../shared/tests/


### PR DESCRIPTION
The latest Inspec packages should now work on AmazonLinux. Opening this PR to re-enable them and also consolidated the `inspec_download` variable into a single place to make version bumping easier in the future. 

Good to go if the build runs and passes across the board. 