### PR TITLE
Fixes #191. Disable only epel repo so Erlang / RabbitMQ installs

### DIFF
--- a/tasks/Amazon/rabbit.yml
+++ b/tasks/Amazon/rabbit.yml
@@ -54,4 +54,4 @@
       - rabbitmq-server
     state: present
     enablerepo: rabbitmq,rabbitmq-erlang
-    disablerepo: '*'
+    disablerepo: 'epel'


### PR DESCRIPTION
Disable only the epel repo (not all) to allow dependencies for Erlang and RabbitMQ to install.