### PR TITLE
Docs - Switch from flatly to readthedocs theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ repo_url: https://github.com/sensu/sensu-ansible
 site_description: An Ansible role to deploy a fully dynamic Sensu stack!
 site_author: Calum MacRae
 
-theme: flatly
+theme: readthedocs
 pages:
   - Home: index.md
   - Usage:


### PR DESCRIPTION
ReadTheDocs currently fails to build with:
```
ERROR   -  Config value: 'theme'. Error: Unrecognised theme name: 'flatly'. The available installed themes are: readthedocs, mkdocs 

Aborted with 1 Configuration Errors!
```

This is an attempt to fix that up. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>