### PR TITLE
The use of 'static' has been deprecated, tags not working in 2.7

### DIFF
--- a/tasks/Amazon/dashboard.yml
+++ b/tasks/Amazon/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to CentOS
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa is installed

--- a/tasks/Amazon/dashboard.yml
+++ b/tasks/Amazon/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/Amazon/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to CentOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa is installed

--- a/tasks/Amazon/dashboard.yml
+++ b/tasks/Amazon/dashboard.yml
@@ -3,13 +3,16 @@
 # Specific to CentOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa is installed
+  tags: dashboard
   yum:
     name: uchiwa
     state: present
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ sensu_config_path }}/uchiwa.json"

--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -3,8 +3,9 @@
 # This takes care of base prerequisites for Amazon Linux AMI
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Set epel_version override when AmazonLinux AMIv2
   tags: setup

--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -3,13 +3,16 @@
 # This takes care of base prerequisites for Amazon Linux AMI
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Set epel_version override when AmazonLinux AMIv2
+  tags: setup
   set_fact:
     epel_version: 7
   when: ansible_distribution_version == 'Candidate'
 
 - name: Ensure the Sensu Core Yum repo is present
+  tags: setup
   yum_repository:
     name: sensu
     description: The Sensu Core yum repository
@@ -19,6 +22,7 @@
     enabled: yes
 
 - name: Ensure Sensu is installed
+  tags: setup
   yum:
     name: "{{ sensu_package }}"
     state: "{{ sensu_pkg_state }}"

--- a/tasks/Amazon/main.yml
+++ b/tasks/Amazon/main.yml
@@ -2,7 +2,8 @@
 # tasks/Amazon/main.yml: CentOS specific set-up
 # This takes care of base prerequisites for Amazon Linux AMI
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Set epel_version override when AmazonLinux AMIv2

--- a/tasks/Amazon/rabbit.yml
+++ b/tasks/Amazon/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/Amazon/rabbit.yml: Deploy RabbitMQ
 # Specific to Amazon Linux
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ/RabbitMQ-erlang GPG keys in the RPM keyring

--- a/tasks/Amazon/rabbit.yml
+++ b/tasks/Amazon/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to Amazon Linux
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ/RabbitMQ-erlang GPG keys in the RPM keyring

--- a/tasks/Amazon/rabbit.yml
+++ b/tasks/Amazon/rabbit.yml
@@ -3,14 +3,17 @@
 # Specific to Amazon Linux
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Configure RabbitMQ/RabbitMQ-erlang GPG keys in the RPM keyring
+  tags: rabbitmq
   rpm_key:
     key: "{{ sensu_rabbitmq_signing_key }}"
     state: present
   register: sensu_rabbitmq_import_key
 
 - name: Add RabbitMQ's repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq
     description: rabbitmq
@@ -20,6 +23,7 @@
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
@@ -31,6 +35,7 @@
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
 # Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
 - name: Make yum cache to import GPG keys
+  tags: rabbitmq
   command: "yum -q makecache -y --disablerepo='*' --enablerepo='{{ item }}'"
   args:
     warn: false
@@ -43,11 +48,13 @@
 # we simply install it here, as we purposely disable epel when installing rabbitmq
 # causing dependency issues during installs
 - name: Ensure socat is installed
+  tags: rabbitmq
   yum:
     name: socat
     state: present
 
 - name: Ensure Erlang & RabbitMQ are installed
+  tags: rabbitmq
   yum:
     name:
       - erlang

--- a/tasks/Amazon/redis.yml
+++ b/tasks/Amazon/redis.yml
@@ -3,7 +3,8 @@
 # Specific to Amazon Linux AMI
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Install EPEL repo

--- a/tasks/Amazon/redis.yml
+++ b/tasks/Amazon/redis.yml
@@ -2,7 +2,8 @@
 # tasks/Amazon/redis.yml: Deploy redis
 # Specific to Amazon Linux AMI
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Install EPEL repo

--- a/tasks/Amazon/redis.yml
+++ b/tasks/Amazon/redis.yml
@@ -3,20 +3,24 @@
 # Specific to Amazon Linux AMI
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Install EPEL repo
+  tags: redis
   yum:
     name: "{{ epel_repo_rpm }}"
     state: present
   when: enable_epel_repo
 
 - name: Ensure redis is installed
+  tags: redis
   yum:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
     enablerepo: epel
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /etc/redis.conf
     regexp: '^bind'

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -2,7 +2,10 @@
 # tasks/CentOS/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to CentOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_varse ansible_distribution vars
+  include_varse ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa is installed

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -3,20 +3,24 @@
 # Specific to CentOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa is installed
+  tags: dashboard
   package:
     name: uchiwa
     state: present
   when: not se_enterprise
 
 - name: Ensure Sensu Enterprise Dashboard is installed
+  tags: dashboard
   package:
     name: "{{ sensu_enterprise_dashboard_package }}"
     state: present
   when: se_enterprise
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ sensu_config_path }}/uchiwa.json"
@@ -26,6 +30,7 @@
 
 
 - name: Deploy Sensu Enterprise Dashboard
+  tags: dashboard
   template:
     src: sensu_enterprise_dashboard_config.json.j2
     dest: "{{ sensu_config_path}}/dashboard.json"

--- a/tasks/CentOS/dashboard.yml
+++ b/tasks/CentOS/dashboard.yml
@@ -3,9 +3,8 @@
 # Specific to CentOS
 
 - name: Include ansible_distribution vars
-  include_varse ansible_distribution vars
-  include_varse ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa is installed
@@ -36,7 +35,7 @@
   tags: dashboard
   template:
     src: sensu_enterprise_dashboard_config.json.j2
-    dest: "{{ sensu_config_path}}/dashboard.json"
+    dest: "{{ sensu_config_path }}/dashboard.json"
   when: se_enterprise
   notify:
     - restart sensu-enterprise-dashboard service

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -3,8 +3,10 @@
 # This takes care of base prerequisites for CentOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure the Sensu Core Yum repo is present
+  tags: setup
   yum_repository:
     name: sensu
     description: The Sensu Core yum repository
@@ -17,6 +19,7 @@
     enabled: yes
 
 - name: Ensure that credential is supplied if installing Sensu Enterprise
+  tags: setup
   assert:
     that:
       - "se_user != ''"
@@ -25,6 +28,7 @@
   when: se_enterprise
 
 - name: Ensure the Sensu Enterprise repo is present
+  tags: setup
   copy:
     dest: /etc/yum.repos.d/sensu-enterprise.repo
     content: |
@@ -39,6 +43,7 @@
   when: se_enterprise
 
 - name: Ensure the Sensu Enterprise Dashboard repo is present
+  tags: setup
   copy:
     dest: /etc/yum.repos.d/sensu-enterprise-dashboard.repo
     content: |
@@ -53,11 +58,13 @@
   when: se_enterprise
 
 - name: Ensure Sensu is installed
+  tags: setup
   package:
     name: "{{ sensu_package }}"
     state: "{{ sensu_pkg_state }}"
 
 - name: Ensure Sensu Enterprise is installed
+  tags: setup
   package:
     name: "{{ sensu_enterprise_package }}"
     state: "{{ sensu_pkg_state }}"

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -3,8 +3,8 @@
 # This takes care of base prerequisites for CentOS
 
 - name: Include ansible_distribution vars
-  include_varse ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu Core Yum repo is present

--- a/tasks/CentOS/main.yml
+++ b/tasks/CentOS/main.yml
@@ -2,7 +2,9 @@
 # tasks/CentOS/main.yml: CentOS specific set-up
 # This takes care of base prerequisites for CentOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_varse ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu Core Yum repo is present

--- a/tasks/CentOS/rabbit.yml
+++ b/tasks/CentOS/rabbit.yml
@@ -2,7 +2,9 @@
 # tasks/CentOS/rabbit.yml: Deploy RabbitMQ
 # Specific to CentOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_varse ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring

--- a/tasks/CentOS/rabbit.yml
+++ b/tasks/CentOS/rabbit.yml
@@ -3,14 +3,17 @@
 # Specific to CentOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring
+  tags: rabbitmq
   rpm_key:
     key: "{{ sensu_rabbitmq_signing_key }}"
     state: present
   register: sensu_rabbitmq_import_key
 
 - name: Add RabbitMQ's repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq
     description: rabbitmq
@@ -20,6 +23,7 @@
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
@@ -31,6 +35,7 @@
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
 # Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
 - name: Make yum cache to import GPG keys
+  tags: rabbitmq
   command: "yum -q makecache -y --disablerepo='*' --enablerepo='{{ item }}'"
   args:
     warn: false
@@ -43,11 +48,13 @@
 # we simply install it here, as we purposely disable epel when installing rabbitmq
 # causing dependency issues during installs
 - name: Ensure socat is installed
+  tags: rabbitmq
   yum:
     name: socat
     state: present
 
 - name: Ensure Erlang & RabbitMQ are installed
+  tags: rabbitmq
   yum:
     name:
       - erlang

--- a/tasks/CentOS/rabbit.yml
+++ b/tasks/CentOS/rabbit.yml
@@ -3,8 +3,8 @@
 # Specific to CentOS
 
 - name: Include ansible_distribution vars
-  include_varse ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring

--- a/tasks/CentOS/redis.yml
+++ b/tasks/CentOS/redis.yml
@@ -3,20 +3,24 @@
 # Specific to CentOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Install EPEL repo
+  tags: redis
   yum:
     name: epel-release
     state: present
   when: enable_epel_repo
 
 - name: Ensure redis is installed
+  tags: redis
   yum:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
     enablerepo: "{{ centos_repository }}"
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /etc/redis.conf
     regexp: '^bind'

--- a/tasks/CentOS/redis.yml
+++ b/tasks/CentOS/redis.yml
@@ -3,8 +3,8 @@
 # Specific to CentOS
 
 - name: Include ansible_distribution vars
-  include_varse ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Install EPEL repo

--- a/tasks/CentOS/redis.yml
+++ b/tasks/CentOS/redis.yml
@@ -2,7 +2,9 @@
 # tasks/CentOS/redis.yml: Deploy redis
 # Specific to CentOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_varse ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Install EPEL repo

--- a/tasks/Debian/dashboard.yml
+++ b/tasks/Debian/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to Debian
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Install uchiwa

--- a/tasks/Debian/dashboard.yml
+++ b/tasks/Debian/dashboard.yml
@@ -3,13 +3,16 @@
 # Specific to Debian
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Install uchiwa
+  tags: dashboard
   apt:
     name: uchiwa
     state: present
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ sensu_config_path }}/uchiwa.json"

--- a/tasks/Debian/dashboard.yml
+++ b/tasks/Debian/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/Debian/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to Debian
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Install uchiwa

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -3,7 +3,8 @@
 # This takes care of base prerequisites for Debian
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure apt-transport-https is installed

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -2,7 +2,8 @@
 # tasks/Debian/main.yml: Debian specific set-up
 # This takes care of base prerequisites for Debian
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure apt-transport-https is installed

--- a/tasks/Debian/main.yml
+++ b/tasks/Debian/main.yml
@@ -3,8 +3,10 @@
 # This takes care of base prerequisites for Debian
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure apt-transport-https is installed
+  tags: setup
   apt:
     name: apt-transport-https
     state: present
@@ -12,22 +14,26 @@
     update_cache: true
 
 - name: Ensure that gnupg is installed for apt_key
+  tags: setup
   apt:
     name: gnupg
     state: present
 
 - name: Ensure the Sensu APT repo GPG key is present
+  tags: setup
   apt_key:
     url: "{{ sensu_apt_key_url }}"
     state: present
 
 - name: Ensure the Sensu Core APT repo is present
+  tags: setup
   apt_repository:
     repo: "{{ sensu_apt_repo_url }}"
     state: present
     update_cache: true
 
 - name: Ensure Sensu is installed
+  tags: setup
   apt:
     name: "{{ sensu_package }}"
     state: "{{ sensu_pkg_state }}"

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to Debian
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -3,13 +3,16 @@
 # Specific to Debian
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present
+  tags: rabbitmq
   apt_key:
     url: "{{ sensu_rabbitmq_signing_key }}"
     state: present
 
 - name: Ensure the RabbitMQ APT repo is present
+  tags: rabbitmq
   apt_repository:
     repo: "{{ sensu_rabbitmq_repo }}"
     filename: rabbitmq
@@ -17,6 +20,7 @@
     update_cache: true
 
 - name: Ensure Erlang APT preferences is configured
+  tags: rabbitmq
   template:
     src: erlang-apt-preferences.j2
     dest: /etc/apt/preferences.d/erlang
@@ -25,11 +29,13 @@
     mode: 0755
 
 - name: Ensure the Erlang APT repo GPG key is present
+  tags: rabbitmq
   apt_key:
     url: "{{ sensu_rabbitmq_erlang_signing_key }}"
     state: present
 
 - name: Ensure the Erlang APT repo is present
+  tags: rabbitmq
   apt_repository:
     repo: "{{ sensu_rabbitmq_erlang_repo }}"
     filename: erlang
@@ -37,6 +43,7 @@
     update_cache: true
 
 - name: Ensure RabbitMQ is installed
+  tags: rabbitmq
   apt:
     name: rabbitmq-server
     state: "{{ rabbitmq_pkg_state }}"

--- a/tasks/Debian/rabbit.yml
+++ b/tasks/Debian/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/Debian/rabbit.yml: Deploy RabbitMQ
 # Specific to Debian
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present

--- a/tasks/Debian/redis.yml
+++ b/tasks/Debian/redis.yml
@@ -3,7 +3,8 @@
 # Specific to Debian
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/Debian/redis.yml
+++ b/tasks/Debian/redis.yml
@@ -2,7 +2,8 @@
 # tasks/Debian/redis.yml: Deploy redis
 # Specific to Debian
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/Debian/redis.yml
+++ b/tasks/Debian/redis.yml
@@ -3,14 +3,17 @@
 # Specific to Debian
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Ensure redis is installed
+  tags: redis
   apt:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
     update_cache: true
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /etc/redis/redis.conf
     regexp: '^bind'
@@ -18,3 +21,4 @@
   notify: restart redis service
 
 - meta: flush_handlers
+  tags: redis

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/Fedora/rabbit.yml: Deploy RabbitMQ
 # Specific to Fedora
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to Fedora
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring

--- a/tasks/Fedora/rabbit.yml
+++ b/tasks/Fedora/rabbit.yml
@@ -3,14 +3,17 @@
 # Specific to Fedora
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Configure RabbitMQ GPG keys in the RPM keyring
+  tags: rabbitmq
   rpm_key:
     key: "{{ sensu_rabbitmq_signing_key }}"
     state: present
   register: sensu_rabbitmq_import_key
 
 - name: Add RabbitMQ's repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq
     description: rabbitmq
@@ -20,6 +23,7 @@
     repo_gpgcheck: no
 
 - name: Add RabbitMQ's Erlang repo
+  tags: rabbitmq
   yum_repository:
     name: rabbitmq-erlang
     description: rabbitmq-erlang
@@ -31,6 +35,7 @@
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
 # Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
 - name: Make yum cache to import GPG keys
+  tags: rabbitmq
   command: "yum -q makecache -y --disablerepo='*' --enablerepo='{{ item }}'"
   args:
     warn: false
@@ -43,11 +48,13 @@
 # we simply install it here, as we purposely disable epel when installing rabbitmq
 # causing dependency issues during installs
 - name: Ensure socat is installed
+  tags: rabbitmq
   dnf:
     name: socat
     state: present
 
 - name: Ensure Erlang & RabbitMQ are installed
+  tags: rabbitmq
   dnf:
     name:
       - erlang

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -3,7 +3,8 @@
 # Specific to Fedora
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure jemalloc is installed as a dependency of Redis

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -3,18 +3,22 @@
 # Specific to Fedora
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Ensure jemalloc is installed as a dependency of Redis
+  tags: redis
   dnf:
     name: jemalloc
     state: present
 
 - name: Ensure redis is installed
+  tags: redis
   dnf:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /etc/redis.conf
     regexp: '^bind'

--- a/tasks/Fedora/redis.yml
+++ b/tasks/Fedora/redis.yml
@@ -2,7 +2,8 @@
 # tasks/Fedora/redis.yml: Deploy redis
 # Specific to Fedora
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure jemalloc is installed as a dependency of Redis

--- a/tasks/FreeBSD/dashboard.yml
+++ b/tasks/FreeBSD/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to FreeBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed

--- a/tasks/FreeBSD/dashboard.yml
+++ b/tasks/FreeBSD/dashboard.yml
@@ -3,8 +3,10 @@
 # Specific to FreeBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed
+  tags: dashboard
   pkgng:
     name: "{{ item }}"
     state: present
@@ -14,6 +16,7 @@
     - npm
 
 - name: Ensure Uchiwa directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}"
     state: directory
@@ -22,6 +25,7 @@
     recurse: true
 
 - name: Ensure Uchiwa Go/config directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/{{ item }}"
     state: directory
@@ -33,6 +37,7 @@
     - go
 
 - name: Ensure Uchiwa GOPATH exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/go/{{ item }}"
     owner: "{{ sensu_user_name }}"
@@ -45,6 +50,7 @@
     - src
 
 - name: Fetch Uchiwa from GitHub
+  tags: dashboard
   command: go get github.com/sensu/uchiwa
   environment:
     GOPATH: "{{ uchiwa_path }}/go"
@@ -55,8 +61,10 @@
   become_user: "{{ sensu_user_name }}"
 
 - meta: flush_handlers
+  tags: dashboard
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ uchiwa_path }}/etc/config.json"
@@ -65,10 +73,12 @@
   notify: restart uchiwa service
 
 - name: Deploy Uchiwa service file
+  tags: dashboard
   template:
     src: uchiwa_freebsd.j2
     dest: "/usr/local/etc/rc.d/uchiwa"
     mode: "0755"
 
 - name: Ensure Uchiwa server service is running
+  tags: dashboard
   service: name=uchiwa state=started enabled=yes

--- a/tasks/FreeBSD/dashboard.yml
+++ b/tasks/FreeBSD/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/FreeBSD/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to FreeBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -2,7 +2,8 @@
 # tasks/FreeBSD/main.yml: FreeBSD specific set-up
 # This takes care of base prerequisites for FreeBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -3,13 +3,14 @@
 # This takes care of base prerequisites for FreeBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present
   tags: setup
   group:
-    name: {{ sensu_group_name }}
+    name: "{{ sensu_group_name }}"
     state: present
 
 - name: Ensure the Sensu user is present

--- a/tasks/FreeBSD/main.yml
+++ b/tasks/FreeBSD/main.yml
@@ -3,13 +3,16 @@
 # This takes care of base prerequisites for FreeBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure the Sensu group is present
+  tags: setup
   group:
     name: {{ sensu_group_name }}
     state: present
 
 - name: Ensure the Sensu user is present
+  tags: setup
   user:
     name: "{{ sensu_user_name }}"
     group: "{{ sensu_group_name }}"
@@ -19,11 +22,13 @@
     state: present
 
 - name: Ensure pkgng custom repo config directory exists
+  tags: setup
   file:
     path: /usr/local/etc/pkg/repos/
     state: directory
 
 - name: Ensure Sensu repo is configured
+  tags: setup
   template:
     src: sensu-freebsd-repo.conf.j2
     dest: /usr/local/etc/pkg/repos/sensu.conf
@@ -31,6 +36,7 @@
     - Update pkgng database
 
 - name: Ensure prerequisite packages are installed
+  tags: setup
   pkgng:
     name: "{{ item }}"
     state: present
@@ -39,6 +45,7 @@
     - ca_root_nss
 
 - name: Ensure Sensu is installed
+  tags: setup
   pkgng:
     name: "{{ sensu_package }}"
     state: "{{ sensu_pkg_state }}"

--- a/tasks/FreeBSD/rabbit.yml
+++ b/tasks/FreeBSD/rabbit.yml
@@ -3,8 +3,10 @@
 # Specific to FreeBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed
+  tags: rabbitmq
   pkgng:
     name: rabbitmq
     state: "{{ rabbitmq_pkg_state }}"

--- a/tasks/FreeBSD/rabbit.yml
+++ b/tasks/FreeBSD/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/FreeBSD/rabbit.yml: Deploy RabbitMQ
 # Specific to FreeBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed

--- a/tasks/FreeBSD/rabbit.yml
+++ b/tasks/FreeBSD/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to FreeBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed

--- a/tasks/FreeBSD/redis.yml
+++ b/tasks/FreeBSD/redis.yml
@@ -3,13 +3,16 @@
 # Specific to FreeBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Ensure redis is installed
+  tags: redis
   pkgng:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /usr/local/etc/redis.conf
     regexp: '^bind'
@@ -17,3 +20,4 @@
   notify: restart redis service
 
 - meta: flush_handlers
+  tags: redis

--- a/tasks/FreeBSD/redis.yml
+++ b/tasks/FreeBSD/redis.yml
@@ -2,7 +2,8 @@
 # tasks/FreeBSD/redis.yml: Deploy redis
 # Specific to FreeBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/FreeBSD/redis.yml
+++ b/tasks/FreeBSD/redis.yml
@@ -3,7 +3,8 @@
 # Specific to FreeBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/OpenBSD/dashboard.yml
+++ b/tasks/OpenBSD/dashboard.yml
@@ -3,8 +3,10 @@
 # Specific to OpenBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed
+  tags: dashboard
   openbsd_pkg:
     name: "{{ item }}"
     state: present
@@ -14,6 +16,7 @@
     - npm
 
 - name: Ensure Uchiwa directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}"
     state: directory
@@ -22,6 +25,7 @@
     recurse: true
 
 - name: Ensure Uchiwa Go/config directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/{{ item }}"
     state: directory
@@ -33,6 +37,7 @@
     - go
 
 - name: Ensure Uchiwa GOPATH exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/go/{{ item }}"
     owner: "{{ sensu_user_name }}"
@@ -45,6 +50,7 @@
     - src
 
 - name: Fetch Uchiwa from GitHub
+  tags: dashboard
   command: go get github.com/sensu/uchiwa
   environment:
     GOPATH: "{{ uchiwa_path }}/go"
@@ -55,8 +61,10 @@
   become_user: "{{ sensu_user_name }}"
 
 - meta: flush_handlers
+  tags: dashboard
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ uchiwa_path }}/etc/config.json"
@@ -65,10 +73,12 @@
   notify: restart uchiwa service
 
 - name: Deploy Uchiwa service file
+  tags: dashboard
   template:
     src: uchiwa_openbsd.j2
     dest: "/usr/local/etc/rc.d/uchiwa"
     mode: "0755"
 
 - name: Ensure Uchiwa server service is running
+  tags: dashboard
   service: name=uchiwa state=started enabled=yes

--- a/tasks/OpenBSD/dashboard.yml
+++ b/tasks/OpenBSD/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to OpenBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed

--- a/tasks/OpenBSD/dashboard.yml
+++ b/tasks/OpenBSD/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/OpenBSD/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to OpenBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed

--- a/tasks/OpenBSD/main.yml
+++ b/tasks/OpenBSD/main.yml
@@ -2,7 +2,8 @@
 # tasks/OpenBSD/main.yml: OpenBSD specific set-up
 # This takes care of base prerequisites for OpenBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present

--- a/tasks/OpenBSD/main.yml
+++ b/tasks/OpenBSD/main.yml
@@ -3,7 +3,8 @@
 # This takes care of base prerequisites for OpenBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present
@@ -45,7 +46,7 @@
   tags: setup
   gem:
     name: sensu
-    repository: "{{ sensu_gem_repository | default('https://api.rubygems.org/')}}"
+    repository: "{{ sensu_gem_repository | default('https://api.rubygems.org/') }}"
     user_install: no
     version: "{{ sensu_gem_version }}"
     executable: /usr/local/bin/gem23

--- a/tasks/OpenBSD/main.yml
+++ b/tasks/OpenBSD/main.yml
@@ -3,11 +3,14 @@
 # This takes care of base prerequisites for OpenBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure the Sensu group is present
+  tags: setup
   group: name={{ sensu_group_name }} state=present
 
 - name: Ensure the Sensu user is present
+  tags: setup
   user:
     name: "{{ sensu_user_name }}"
     group: "{{ sensu_group_name }}"
@@ -17,6 +20,7 @@
     state: present
 
 - name: Install prerequisite packages
+  tags: setup
   openbsd_pkg:
     name: "{{ item }}"
     state: present
@@ -25,16 +29,19 @@
     - ruby%2.3
 
 - name: Get the current version of rubygems
+  tags: setup
   shell: /usr/local/bin/gem23 --version
   check_mode: no
   register: gem23_version
   changed_when: False
 
 - name: Update rubygems to work around rubygems/rubygems/issues/1448
+  tags: setup
   shell: /usr/local/bin/gem23 update --system
   when: "{{ gem23_version.stdout | version_compare('2.5.3', '<') }}"
 
 - name: Install sensu gem and all of its dependencies
+  tags: setup
   gem:
     name: sensu
     repository: "{{ sensu_gem_repository | default('https://api.rubygems.org/')}}"
@@ -43,6 +50,7 @@
     executable: /usr/local/bin/gem23
 
 - name: Create the sensu log folder
+  tags: setup
   file:
     path: /var/log/sensu
     owner: root
@@ -50,6 +58,7 @@
     state: directory
 
 - name: Deploy OpenBSD rc script
+  tags: setup
   template:
     src: sensuclient_openbsd.j2
     dest: /etc/rc.d/sensuclient

--- a/tasks/OpenBSD/rabbit.yml
+++ b/tasks/OpenBSD/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to OpenBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed

--- a/tasks/OpenBSD/rabbit.yml
+++ b/tasks/OpenBSD/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/OpenBSD/rabbit.yml: Deploy RabbitMQ
 # Specific to OpenBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed

--- a/tasks/OpenBSD/rabbit.yml
+++ b/tasks/OpenBSD/rabbit.yml
@@ -3,8 +3,10 @@
 # Specific to OpenBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Ensure RabbitMQ is installed
+  tags: rabbitmq
   pkgng:
     name: rabbitmq
     state: "{{ rabbitmq_pkg_state }}"

--- a/tasks/OpenBSD/redis.yml
+++ b/tasks/OpenBSD/redis.yml
@@ -2,7 +2,8 @@
 # tasks/OpenBSD/redis.yml: Deploy redis
 # Specific to OpenBSD
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/OpenBSD/redis.yml
+++ b/tasks/OpenBSD/redis.yml
@@ -3,7 +3,8 @@
 # Specific to OpenBSD
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/OpenBSD/redis.yml
+++ b/tasks/OpenBSD/redis.yml
@@ -3,13 +3,16 @@
 # Specific to OpenBSD
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Ensure redis is installed
+  tags: redis
   pkgng:
     name: "{{ redis_pkg_name }}"
     state: "{{ redis_pkg_state }}"
 
 - name: Ensure redis binds to accessible IP
+  tags: redis
   lineinfile:
     dest: /usr/local/etc/redis.conf
     regexp: '^bind'
@@ -17,3 +20,4 @@
   notify: restart redis service
 
 - meta: flush_handlers
+  tags: redis

--- a/tasks/SmartOS/client.yml
+++ b/tasks/SmartOS/client.yml
@@ -2,7 +2,8 @@
 # tasks/SmartOS/client.yml: Deploy various client-side configurations for Sensu
 # Specific to Joyent SmartOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: client
 
 - name: Deploy Sensu client service manifest

--- a/tasks/SmartOS/client.yml
+++ b/tasks/SmartOS/client.yml
@@ -3,8 +3,10 @@
 # Specific to Joyent SmartOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: client
 
 - name: Deploy Sensu client service manifest
+  tags: client
   template:
     dest: /opt/local/lib/svc/manifest/sensu-client.xml
     src: sensu-client.smartos_smf_manifest.xml.j2
@@ -16,3 +18,4 @@
     - restart sensu-client service
 
 - meta: flush_handlers
+  tags: client

--- a/tasks/SmartOS/client.yml
+++ b/tasks/SmartOS/client.yml
@@ -3,7 +3,8 @@
 # Specific to Joyent SmartOS
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: client
 
 - name: Deploy Sensu client service manifest

--- a/tasks/SmartOS/dashboard.yml
+++ b/tasks/SmartOS/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to Joyent SmartOS
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed
@@ -84,7 +85,7 @@
     src: uchiwa.smartos_smf_manifest.xml.j2
     owner: root
     group: root
-    mode: 644
+    mode: 0644
   notify: import uchiwa service
 
 - meta: flush_handlers

--- a/tasks/SmartOS/dashboard.yml
+++ b/tasks/SmartOS/dashboard.yml
@@ -3,11 +3,14 @@
 # Specific to Joyent SmartOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed
+  tags: dashboard
   pkgin: name=go state=present
 
 - name: Ensure Uchiwa directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}"
     state: directory
@@ -16,6 +19,7 @@
     recurse: true
 
 - name: Ensure Uchiwa Go/config directory exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/{{ item }}"
     state: directory
@@ -27,6 +31,7 @@
     - go
 
 - name: Ensure Uchiwa GOPATH exists
+  tags: dashboard
   file:
     dest: "{{ uchiwa_path }}/go/{{ item }}"
     owner: "{{ sensu_user_name }}"
@@ -39,6 +44,7 @@
     - src
 
 - name: Fetch Uchiwa from GitHub
+  tags: dashboard
   command: go get github.com/sensu/uchiwa
   environment:
     GOPATH: "{{ uchiwa_path }}/go"
@@ -49,8 +55,10 @@
   become_user: "{{ sensu_user_name }}"
 
 - meta: flush_handlers
+  tags: dashboard
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ uchiwa_path }}/etc/config.json"
@@ -59,6 +67,7 @@
   notify: restart uchiwa service
 
 - name: Deploy Uchiwa service script
+  tags: dashboard
   template:
     src: uchiwa.sh.j2
     dest: /opt/local/lib/svc/method/uchiwa
@@ -68,6 +77,7 @@
   notify: restart uchiwa service
 
 - name: Deploy Uchiwa service manifest
+  tags: dashboard
   template:
     dest: /opt/local/lib/svc/manifest/uchiwa.xml
     src: uchiwa.smartos_smf_manifest.xml.j2
@@ -77,6 +87,8 @@
   notify: import uchiwa service
 
 - meta: flush_handlers
+  tags: dashboard
 
 - name: Ensure Uchiwa server service is running
   service: name=uchiwa state=started enabled=yes
+  tags: dashboard

--- a/tasks/SmartOS/dashboard.yml
+++ b/tasks/SmartOS/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/SmartOS/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to Joyent SmartOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa (dashboard) dependencies are installed

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -3,11 +3,14 @@
 # This takes care of base prerequisites for Joyent SmartOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure the Sensu group is present
+  tags: setup
   group: name={{ sensu_group_name }} state=present
 
 - name: Ensure the Sensu user is present
+  tags: setup
   user:
     name: "{{ sensu_user_name }}"
     group: "{{ sensu_group_name }}"
@@ -17,12 +20,15 @@
     state: present
 
 - name: Ensure Sensu dependencies are installed
+  tags: setup
   pkgin: name=build-essential,ruby21-base state=present
 
 - name: Ensure Sensu is installed
+  tags: setup
   gem: name=sensu state={{ sensu_gem_state }} user_install=no
   notify:
     - restart sensu-client service
 
 - name: Ensure Sensu 'plugins' gem is installed
+  tags: setup
   gem: name=sensu-plugin state={{ sensu_plugin_gem_state }} user_install=no

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -3,7 +3,8 @@
 # This takes care of base prerequisites for Joyent SmartOS
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present

--- a/tasks/SmartOS/main.yml
+++ b/tasks/SmartOS/main.yml
@@ -2,7 +2,8 @@
 # tasks/SmartOS/main.yml: "Set-up" playbook for sensu.sensu role
 # This takes care of base prerequisites for Joyent SmartOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure the Sensu group is present

--- a/tasks/SmartOS/rabbit.yml
+++ b/tasks/SmartOS/rabbit.yml
@@ -3,9 +3,11 @@
 # Specific to Joyent SmartOS
 
 - name: Ensure RabbitMQ is installed
+  tags: rabbitmq
   pkgin: name=rabbitmq state=present
 
 - name: Ensure EPMD is running
+  tags: rabbitmq
   service:
     name: epmd
     state: started

--- a/tasks/SmartOS/redis.yml
+++ b/tasks/SmartOS/redis.yml
@@ -3,6 +3,8 @@
 # Specific to Ubuntu
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: redis
 
 - name: Ensure redis is installed
+  tags: redis
   pkgin: name=redis state={{ redis_pkg_state }}

--- a/tasks/SmartOS/redis.yml
+++ b/tasks/SmartOS/redis.yml
@@ -2,7 +2,8 @@
 # tasks/SmartOS/redis.yml: Deploy redis
 # Specific to Ubuntu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/SmartOS/redis.yml
+++ b/tasks/SmartOS/redis.yml
@@ -3,7 +3,8 @@
 # Specific to Ubuntu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: redis
 
 - name: Ensure redis is installed

--- a/tasks/SmartOS/server.yml
+++ b/tasks/SmartOS/server.yml
@@ -3,7 +3,8 @@
 # a Sensu 'master' node.
 # Specific to SmartOS
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: server
 
 - name: Deploy Sensu server service manifest

--- a/tasks/SmartOS/server.yml
+++ b/tasks/SmartOS/server.yml
@@ -4,8 +4,10 @@
 # Specific to SmartOS
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: server
 
 - name: Deploy Sensu server service manifest
+  tags: server
   template:
     dest: /opt/local/lib/svc/manifest/sensu-server.xml
     src: sensu-server.smartos_smf_manifest.xml.j2
@@ -15,6 +17,7 @@
   notify: import sensu-server service
 
 - name: Deploy Sensu API service manifest
+  tags: server
   template:
     dest: /opt/local/lib/svc/manifest/sensu-api.xml
     src: sensu-api.smartos_smf_manifest.xml.j2
@@ -24,3 +27,4 @@
   notify: import sensu-api service
 
 - meta: flush_handlers
+  tags: server

--- a/tasks/SmartOS/server.yml
+++ b/tasks/SmartOS/server.yml
@@ -4,7 +4,8 @@
 # Specific to SmartOS
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: server
 
 - name: Deploy Sensu server service manifest

--- a/tasks/Ubuntu/dashboard.yml
+++ b/tasks/Ubuntu/dashboard.yml
@@ -2,7 +2,8 @@
 # tasks/Ubuntu/dashboard.yml: Deployment of the Uchiwa dashboard
 # Specific to Ubuntu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Install Uchiwa

--- a/tasks/Ubuntu/dashboard.yml
+++ b/tasks/Ubuntu/dashboard.yml
@@ -3,13 +3,16 @@
 # Specific to Ubuntu
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: dashboard
 
 - name: Install Uchiwa
+  tags: dashboard
   apt:
     name: uchiwa
     state: present
 
 - name: Deploy Uchiwa config
+  tags: dashboard
   template:
     src: uchiwa_config.json.j2
     dest: "{{ sensu_config_path }}/uchiwa.json"

--- a/tasks/Ubuntu/dashboard.yml
+++ b/tasks/Ubuntu/dashboard.yml
@@ -3,7 +3,8 @@
 # Specific to Ubuntu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: dashboard
 
 - name: Install Uchiwa

--- a/tasks/Ubuntu/main.yml
+++ b/tasks/Ubuntu/main.yml
@@ -2,7 +2,8 @@
 # tasks/Ubuntu/main.yml: Ubuntu specific set-up
 # This takes care of base prerequisites for Ubuntu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure that https transport is ready

--- a/tasks/Ubuntu/main.yml
+++ b/tasks/Ubuntu/main.yml
@@ -3,8 +3,10 @@
 # This takes care of base prerequisites for Ubuntu
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: setup
 
 - name: Ensure that https transport is ready
+  tags: setup
   apt:
     name: apt-transport-https
     state: present
@@ -12,17 +14,20 @@
     update_cache: true
 
 - name: Ensure the Sensu APT repo GPG key is present
+  tags: setup
   apt_key:
     url: "{{ sensu_apt_key_url }}"
     state: present
 
 - name: Ensure the Sensu Core APT repo is present
+  tags: setup
   apt_repository:
     repo: "{{ sensu_apt_repo_url }}"
     state: present
     update_cache: true
 
 - name: Ensure Sensu is installed
+  tags: setup
   apt:
     name: "{{ sensu_package }}"
     state: "{{ sensu_pkg_state }}"

--- a/tasks/Ubuntu/main.yml
+++ b/tasks/Ubuntu/main.yml
@@ -3,7 +3,8 @@
 # This takes care of base prerequisites for Ubuntu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: setup
 
 - name: Ensure that https transport is ready

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/Ubuntu/rabbit.yml: Deploy RabbitMQ
 # Specific to Ubuntu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -3,7 +3,8 @@
 # Specific to Ubuntu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present

--- a/tasks/Ubuntu/rabbit.yml
+++ b/tasks/Ubuntu/rabbit.yml
@@ -3,13 +3,16 @@
 # Specific to Ubuntu
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - name: Ensure the RabbitMQ APT repo GPG key is present
+  tags: rabbitmq
   apt_key:
     url: "{{ sensu_rabbitmq_signing_key }}"
     state: present
 
 - name: Ensure the RabbitMQ APT repo is present
+  tags: rabbitmq
   apt_repository:
     repo: "{{ sensu_rabbitmq_repo }}"
     filename: rabbitmq
@@ -17,6 +20,7 @@
     update_cache: true
 
 - name: Ensure Erlang APT preferences is configured
+  tags: rabbitmq
   template:
     src: erlang-apt-preferences.j2
     dest: /etc/apt/preferences.d/erlang
@@ -25,11 +29,13 @@
     mode: 0755
 
 - name: Ensure the Erlang APT repo GPG key is present
+  tags: rabbitmq
   apt_key:
     url: "{{ sensu_rabbitmq_erlang_signing_key }}"
     state: present
 
 - name: Ensure the Erlang APT repo is present
+  tags: rabbitmq
   apt_repository:
     repo: "{{ sensu_rabbitmq_erlang_repo }}"
     filename: erlang
@@ -37,6 +43,7 @@
     update_cache: true
 
 - name: Ensure RabbitMQ is installed
+  tags: rabbitmq
   apt:
     name: rabbitmq-server
     state: "{{ rabbitmq_pkg_state }}"

--- a/tasks/Ubuntu/redis.yml
+++ b/tasks/Ubuntu/redis.yml
@@ -2,7 +2,8 @@
 # tasks/Ubuntu/redis.yml: Deploy redis
 # Specific to Ubuntu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Ensure redis is installed
   apt:

--- a/tasks/Ubuntu/redis.yml
+++ b/tasks/Ubuntu/redis.yml
@@ -3,7 +3,8 @@
 # Specific to Ubuntu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Ensure redis is installed
   apt:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/client.yml: Deploy various client-side configurations for Sensu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: client
 
 - name: Deploy Sensu client service configuration

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -2,8 +2,10 @@
 # tasks/client.yml: Deploy various client-side configurations for Sensu
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: client
 
 - name: Deploy Sensu client service configuration
+  tags: client
   template:
     dest: "{{ sensu_config_path }}/conf.d/client.json"
     owner: "{{ sensu_user_name }}"
@@ -13,9 +15,11 @@
   notify: restart sensu-client service
 
 - include_tasks: "{{ role_path }}/tasks/SmartOS/client.yml"
+  tags: client
   when: ansible_distribution == "SmartOS"
 
 - name: Ensure Sensu client service is running
+  tags: client
   service:
     name: "{{ sensu_client_service_name }}"
     state: started

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -12,9 +12,8 @@
     mode: "0640"
   notify: restart sensu-client service
 
-- include: "{{ role_path }}/tasks/SmartOS/client.yml"
+- include_tasks: "{{ role_path }}/tasks/SmartOS/client.yml"
   when: ansible_distribution == "SmartOS"
-  static: false
 
 - name: Ensure Sensu client service is running
   service:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -2,7 +2,8 @@
 # tasks/client.yml: Deploy various client-side configurations for Sensu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: client
 
 - name: Deploy Sensu client service configuration

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -2,7 +2,8 @@
 # tasks/common.yml: Deploy configurations common to client and server for Sensu
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Ensure the Sensu config directory is present
   file:

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/common.yml: Deploy configurations common to client and server for Sensu
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Ensure the Sensu config directory is present
   file:

--- a/tasks/dashboard.yml
+++ b/tasks/dashboard.yml
@@ -1,6 +1,7 @@
 ---
 # tasks/dashboard.yml: Deployment of the Uchiwa dashboard
-- include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/dashboard.yml"
+- name: Include ansible_distribution vars
+  include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/dashboard.yml"
   tags: dashboard
 
 - name: Ensure Uchiwa/Sensu Enterprise Dashboard server service is running

--- a/tasks/dashboard.yml
+++ b/tasks/dashboard.yml
@@ -1,6 +1,6 @@
 ---
 # tasks/dashboard.yml: Deployment of the Uchiwa dashboard
-- include: "{{ role_path }}/tasks/{{ ansible_distribution }}/dashboard.yml"
+- include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/dashboard.yml"
 
 - name: Ensure Uchiwa/Sensu Enterprise Dashboard server service is running
   service:

--- a/tasks/dashboard.yml
+++ b/tasks/dashboard.yml
@@ -1,8 +1,10 @@
 ---
 # tasks/dashboard.yml: Deployment of the Uchiwa dashboard
 - include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/dashboard.yml"
+  tags: dashboard
 
 - name: Ensure Uchiwa/Sensu Enterprise Dashboard server service is running
+  tags: dashboard
   service:
     name: "{{ uchiwa_service_name if not se_enterprise else sensu_enterprise_dashboard_service_name }}"
     state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,8 @@
 # tasks/main.yml: "Master" playbook for the sensu.sensu role
 
 - name: Include distribution specific variables
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/main.yml"
   tags: setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,46 +4,41 @@
 - name: Include distribution specific variables
   include_vars: "{{ ansible_distribution }}.yml"
 
-- include: "{{ role_path }}/tasks/{{ ansible_distribution }}/main.yml"
+- include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/main.yml"
   tags: setup
   when: sensu_master
         or sensu_client
 
-- include: "{{ role_path }}/tasks/redis.yml"
+- import_tasks: "redis.yml"
   tags: redis
   when: redis_server
         and sensu_deploy_redis_server
-  static: false
 
-- include: "{{ role_path }}/tasks/ssl.yml"
+- import_tasks: "ssl.yml"
   tags: ssl
 
-- include: "{{ role_path }}/tasks/rabbit.yml"
+- import_tasks: "rabbit.yml"
   tags: rabbitmq
   when: rabbitmq_server
         and sensu_deploy_rabbitmq_server
-  static: false
 
-- include: "{{ role_path }}/tasks/common.yml"
+- import_tasks: "common.yml"
   tags: common
   when: sensu_master
         or sensu_client
 
-- include: "{{ role_path }}/tasks/server.yml"
+- import_tasks: "server.yml"
   tags: server
   when: sensu_master
-  static: false
 
-- include: "{{ role_path }}/tasks/dashboard.yml"
+- import_tasks: "dashboard.yml"
   tags: dashboard
   when: sensu_include_dashboard
-  static: false
 
-- include: "{{ role_path }}/tasks/client.yml"
+- import_tasks: "client.yml"
   tags: client
   when: sensu_client
 
-- include: "{{ role_path }}/tasks/plugins.yml"
+- import_tasks: "plugins.yml"
   tags: plugins
   when: sensu_include_plugins
-  static: false

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -2,7 +2,8 @@
 # tasks/plugins.yml: Deploy available checks/plugins/handlers/filters/mutators
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Ensure Sensu plugin directory exists
   file:
@@ -79,7 +80,7 @@
 - name: Deploy check/handler/filter/mutator definitions to the master
   template:
     src: "{{ item }}"
-    dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '')}}"
+    dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '') }}"
     owner: "{{ sensu_user_name }}"
     group: "{{ sensu_group_name }}"
   when: sensu_master
@@ -99,7 +100,7 @@
 - name: Deploy client definitions
   copy:
     src: "{{ static_data_store }}/sensu/client_definitions/{{ item }}/"
-    dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '')}}"
+    dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '') }}"
     owner: "{{ sensu_user_name }}"
     group: "{{ sensu_group_name }}"
   when:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/plugins.yml: Deploy available checks/plugins/handlers/filters/mutators
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Ensure Sensu plugin directory exists
   file:

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -3,7 +3,7 @@
 
 - include_vars: "{{ ansible_distribution }}.yml"
 
-- include: "{{ ansible_distribution }}/rabbit.yml"
+- include_tasks: "{{ ansible_distribution }}/rabbit.yml"
 
 - name: Ensure RabbitMQ SSL directory exists
   file:

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -2,7 +2,8 @@
 # tasks/rabbit.yml: Deploy RabbitMQ and set-up vhost for Sensu messaging
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - include_tasks: "{{ ansible_distribution }}/rabbit.yml"

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/rabbit.yml: Deploy RabbitMQ and set-up vhost for Sensu messaging
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: rabbitmq
 
 - include_tasks: "{{ ansible_distribution }}/rabbit.yml"

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -2,15 +2,19 @@
 # tasks/rabbit.yml: Deploy RabbitMQ and set-up vhost for Sensu messaging
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: rabbitmq
 
 - include_tasks: "{{ ansible_distribution }}/rabbit.yml"
+  tags: rabbitmq
 
 - name: Ensure RabbitMQ SSL directory exists
+  tags: rabbitmq
   file:
     dest: "{{ rabbitmq_config_path }}/ssl"
     state: directory
 
 - name: Ensure RabbitMQ SSL certs/keys are in place
+  tags: rabbitmq
   copy:
     src: "{{ item.src }}"
     dest: "{{ rabbitmq_config_path }}/ssl/{{ item.dest }}"
@@ -27,6 +31,7 @@
   when: sensu_ssl_manage_certs
 
 - name: Deploy RabbitMQ config
+  tags: rabbitmq
   template:
     dest: "{{ rabbitmq_config_path }}/rabbitmq.config"
     src: "{{ rabbitmq_config_template }}"
@@ -36,6 +41,7 @@
   notify: restart rabbitmq service
 
 - name: Ensure RabbitMQ is running
+  tags: rabbitmq
   service:
     name: "{{ rabbitmq_service_name }}"
     state: started
@@ -43,17 +49,20 @@
   register: rabbitmq_state
 
 - name: Wait for RabbitMQ to be up and running before asking to create a vhost
+  tags: rabbitmq
   pause:
     seconds: 3
   when: rabbitmq_state is changed
 
 - block:
     - name: Ensure Sensu RabbitMQ vhost exists
+      tags: rabbitmq
       rabbitmq_vhost:
         name: "{{ rabbitmq_sensu_vhost }}"
         state: present
 
     - name: Ensure Sensu RabbitMQ user has access to the Sensu vhost
+      tags: rabbitmq
       rabbitmq_user:
         user: "{{ rabbitmq_sensu_user_name }}"
         password: "{{ rabbitmq_sensu_password }}"

--- a/tasks/rabbit.yml
+++ b/tasks/rabbit.yml
@@ -56,13 +56,11 @@
 
 - block:
     - name: Ensure Sensu RabbitMQ vhost exists
-      tags: rabbitmq
       rabbitmq_vhost:
         name: "{{ rabbitmq_sensu_vhost }}"
         state: present
 
     - name: Ensure Sensu RabbitMQ user has access to the Sensu vhost
-      tags: rabbitmq
       rabbitmq_user:
         user: "{{ rabbitmq_sensu_user_name }}"
         password: "{{ rabbitmq_sensu_password }}"
@@ -73,3 +71,4 @@
         state: present
   become: true
   become_user: rabbitmq
+  tags: rabbitmq

--- a/tasks/redis.yml
+++ b/tasks/redis.yml
@@ -1,7 +1,7 @@
 ---
 # tasks/redis.yml: Deploy redis
 
-- include: "{{ role_path }}/tasks/{{ ansible_distribution }}/redis.yml"
+- include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/redis.yml"
 
 - name: Ensure redis is running
   service:

--- a/tasks/redis.yml
+++ b/tasks/redis.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/redis.yml: Deploy redis
 
-- include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/redis.yml"
+- name: Include ansible_distribution vars
+  include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/redis.yml"
   tags: redis
 
 - name: Ensure redis is running

--- a/tasks/redis.yml
+++ b/tasks/redis.yml
@@ -2,8 +2,10 @@
 # tasks/redis.yml: Deploy redis
 
 - include_tasks: "{{ role_path }}/tasks/{{ ansible_distribution }}/redis.yml"
+  tags: redis
 
 - name: Ensure redis is running
+  tags: redis
   service:
     name: "{{ redis_service_name }}"
     pattern: /usr/bin/redis-server

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -2,7 +2,8 @@
 # tasks/server.yml: Deploy Sensu Server/API
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
   tags: server
 
 - name: Deploy Sensu server API configuration

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -2,8 +2,10 @@
 # tasks/server.yml: Deploy Sensu Server/API
 
 - include_vars: "{{ ansible_distribution }}.yml"
+  tags: server
 
 - name: Deploy Sensu server API configuration
+  tags: server
   template:
     dest: "{{ sensu_config_path }}/conf.d/api.json"
     owner: "{{ sensu_user_name }}"
@@ -12,6 +14,7 @@
   notify: restart sensu-api service
 
 - name: Deploy Tessen server configuratiuon
+  tags: server
   template:
     dest: "{{ sensu_config_path }}/conf.d/tessen.json"
     owner: "{{ sensu_user_name }}"
@@ -20,15 +23,18 @@
   notify: restart sensu-server service
 
 - include_tasks: "{{ role_path }}/tasks/SmartOS/server.yml"
+  tags: server
   when: ansible_distribution == "SmartOS"
 
 - name: Ensure Sensu server service is running
+  tags: server
   service:
     name: "{{ sensu_server_service_name if not se_enterprise else sensu_enterprise_service_name }}"
     state: started
     enabled: yes
 
 - name: Ensure Sensu API service is running
+  tags: server
   service:
     name: sensu-api
     state: started

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -19,9 +19,8 @@
     src: sensu-tessen.json.j2
   notify: restart sensu-server service
 
-- include: "{{ role_path }}/tasks/SmartOS/server.yml"
+- include_tasks: "{{ role_path }}/tasks/SmartOS/server.yml"
   when: ansible_distribution == "SmartOS"
-  static: false
 
 - name: Ensure Sensu server service is running
   service:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/server.yml: Deploy Sensu Server/API
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
   tags: server
 
 - name: Deploy Sensu server API configuration

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -2,7 +2,8 @@
 # tasks/ssl.yml: Deploy the client SSL cert/key to client systems
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Ensure Sensu SSL directory exists
   file:

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -11,9 +11,8 @@
     group: "{{ sensu_group_name }}"
   when: sensu_ssl_manage_certs
 
-- include: "{{ role_path }}/tasks/ssl_generate.yml"
+- include_tasks: "{{ role_path }}/tasks/ssl_generate.yml"
   when: sensu_ssl_gen_certs
-  static: false
 
 - name: Deploy the Sensu client SSL cert/key
   copy:

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -1,7 +1,8 @@
 ---
 # tasks/ssl.yml: Deploy the client SSL cert/key to client systems
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Ensure Sensu SSL directory exists
   file:

--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -3,7 +3,8 @@
 # data store for deployment to clients
 
 - name: Include ansible_distribution vars
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars:
+    file: "{{ ansible_distribution }}.yml"
 
 - name: Ensure OpenSSL is installed
   package:

--- a/tasks/ssl_generate.yml
+++ b/tasks/ssl_generate.yml
@@ -2,7 +2,8 @@
 # tasks/ssl_generate.yml: Generate SSL data and stash to dynamic
 # data store for deployment to clients
 
-- include_vars: "{{ ansible_distribution }}.yml"
+- name: Include ansible_distribution vars
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Ensure OpenSSL is installed
   package:


### PR DESCRIPTION
The following notices every run on Ansble 2.7, perhaps eralier and tags would not run anything.

- The use of 'static' has been deprecated.
- Use 'import_tasks' for static inclusion, or 'include_tasks' for dynamic inclusion.

```bash
ansible-playbook sensu.yml --tags plugins
ansible-playbook sensu.yml --tags client,server
ansible-playbook sensu.yml --tags ssl
```

setup tag still does not work due to issues with include_tasks

```bash
ansible-playbook sensu.yml --tags setup
```