### PR TITLE
Bump minimum Ansible to 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Or, passing parameter values:
 ```
 
 ## Ansible version support
-All changes to this role are actively tested against Ansible 2.3 and 2.4 at this time. Ansible 2.3 is required at a minimum.
+All changes to this role are actively tested against Ansible 2.6 and 2.7 at this time. Ansible 2.4 is required at a minimum.
 
 
 License

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Along with deploying the Sensu Server, API and clients, this role can deploy a f
 However, if you want to rely on other roles/management methods to deploy/manage these services, [it's nice and easy to integrate this role](integration/).
 
 ## Requirements
-This role requires Ansible 2.3
+This role requires Ansible 2.4
 
 ## Supported Platforms
 ### Automatically tested via TravisCI

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Calum MacRae
   description: Deploy a full Sensu monitoring stack; including redis, RabbitMQ & the Uchiwa dashboard
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Related to https://github.com/sensu/sensu-ansible/issues/166 and https://github.com/sensu/sensu-ansible/issues/156 and to follow up to https://github.com/sensu/sensu-ansible/pull/200, this officially drops Ansible 2.3 as support for this role. I'll cut this as 3.0.0 as anyone still on Ansible 2.3 will have to upgrade to at least 2.4 in order to run the next release. 


Signed-off-by: Jared Ledvina <jared@techsmix.net>