### PR TITLE
feat(molecule) Re-enable Ubuntu 18 tests

### DIFF
--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -20,14 +20,13 @@ platforms:
       - SYS_ADMIN
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-# Disabled for now, missing Sensu and RabbitMQ packages, total mess to override in tests
-#  - name: ubuntu-18.04
-#    image: dokken/ubuntu-18.04
-#    command: /bin/systemd
-#    capabilities:
-#      - SYS_ADMIN
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: ubuntu-18.04
+    image: dokken/ubuntu-18.04
+    command: /bin/systemd
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
Results of local tests.

```bash
    PLAY RECAP *********************************************************************
    ubuntu-14.04               : ok=84   changed=54   unreachable=0    failed=0
    ubuntu-16.04               : ok=82   changed=54   unreachable=0    failed=0
    ubuntu-18.04               : ok=82   changed=53   unreachable=0    failed=0

    Saturday 16 February 2019  20:03:13 -0500 (0:00:00.121)       0:06:20.287 *****
    ===============================================================================
    sensu-ansible : Ensure RabbitMQ is installed --------------------------- 48.61s
    sensu-ansible : Ensure that https transport is ready ------------------- 31.12s
    sensu-ansible : Ensure redis is installed ------------------------------ 29.82s
    sensu-ansible : Install Uchiwa ----------------------------------------- 21.42s
    sensu-ansible : Ensure Sensu is installed ------------------------------ 20.82s
    sensu-ansible : restart rabbitmq service ------------------------------- 20.35s
    sensu-ansible : Ensure the Erlang APT repo GPG key is present ---------- 15.52s
    sensu-ansible : Ensure the RabbitMQ APT repo GPG key is present -------- 14.65s
    sensu-ansible : Ensure the Sensu APT repo GPG key is present ----------- 14.35s
    sensu-ansible : Ensure the Erlang APT repo is present ------------------ 13.70s
    sensu-ansible : Ensure the RabbitMQ APT repo is present ---------------- 12.22s
    sensu-ansible : Ensure the Sensu Core APT repo is present -------------- 11.27s
    sensu-ansible : Ensure RabbitMQ is running ------------------------------ 7.60s
    sensu-ansible : Ensure OpenSSL is installed ----------------------------- 7.31s
    sensu-ansible : Ensure RabbitMQ SSL certs/keys are in place ------------- 6.56s
    sensu-ansible : Ensure Sensu RabbitMQ user has access to the Sensu vhost --- 6.43s
    sensu-ansible : Stash the Sensu SSL certs/keys -------------------------- 6.08s
    Gathering Facts --------------------------------------------------------- 5.10s
    sensu-ansible : Deploy the Sensu client SSL cert/key -------------------- 4.14s
    sensu-ansible : restart sensu-client service ---------------------------- 4.11s
    Playbook run took 0 days, 0 hours, 6 minutes, 20 seconds
```