### PR TITLE
Client Definations - Switch from copy to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- `client_definitions` now uses `template` instead of `copy` to support native Jinja templates (@jaredledvina)
 
 ## [5.0.0] - 2019-02-19
 ### Breaking Changes

--- a/docs/dynamic_checks.md
+++ b/docs/dynamic_checks.md
@@ -121,7 +121,7 @@ These are deployed with the following pair of plays, also in the `tasks/plugins.
   become: false
 
 - name: Deploy client definitions
-  copy:
+  template:
     src: "{{ static_data_store }}/sensu/client_definitions/{{ item }}/"
     dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '')}}"
     mode: 0755

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -102,7 +102,7 @@
   become: false
 
 - name: Deploy client definitions
-  copy:
+  template:
     src: "{{ static_data_store }}/sensu/client_definitions/{{ item }}/"
     dest: "{{ sensu_config_path }}/conf.d/{{ item | basename | regex_replace('.j2', '') }}"
     owner: "{{ sensu_user_name }}"


### PR DESCRIPTION
Initial shot at resolving https://github.com/sensu/sensu-ansible/issues/211 by switching this to `template`. Opening the PR to see if the integration tests pass. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>