### PR TITLE
bintray.com/rabbitmq/rpm/erlang is going away

### DIFF
--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -17,4 +17,4 @@ sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ epel_version }}"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
-sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ epel_version }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ epel_version }}"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -10,4 +10,4 @@ sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/{{ ansible_distribution_major_version }}"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
-sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ ansible_distribution_major_version }}"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/{{ ansible_distribution_major_version }}"

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -9,4 +9,4 @@ sensu_rabbitmq_erlang_repo_version: 20
 sensu_rabbitmq_signing_key: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 sensu_rabbitmq_baseurl: "https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/{{ sensu_rabbitmq_repo_version }}/el/7"
 sensu_rabbitmq_erlang_signing_key: "{{ sensu_rabbitmq_signing_key }}"
-sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/7"
+sensu_rabbitmq_erlang_baseurl: "https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/{{ sensu_rabbitmq_erlang_repo_version }}/el/7"


### PR DESCRIPTION
Moved to bintray.com/rabbitmq-erlang/rpm/erlang.

Closes #220.