### PR TITLE
Updating sensu apt repo url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ sensu_enterprise_dashboard_package: sensu-enterprise-dashboard
 # Sensu repo urls
 sensu_yum_repo_url: "https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/"
 sensu_yum_key_url: "https://sensu.global.ssl.fastly.net/yum/pubkey.gpg"
-sensu_apt_repo_url: "deb     https://repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
+sensu_apt_repo_url: "deb     https://eol-repositories.sensuapp.org/apt {{ ansible_distribution_release }} main"
 sensu_apt_key_url: "https://sensu.global.ssl.fastly.net/apt/pubkey.gpg"
 sensu_freebsd_url: "https://sensu.global.ssl.fastly.net/freebsd/FreeBSD:{{ ansible_distribution_major_version }}:{{ ansible_architecture }}/"
 sensu_ol_yum_repo_url: "https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/"


### PR DESCRIPTION
Updating the sensu apt repo url as Sensu Core is eol and the url has changed.